### PR TITLE
feat: add custom entry buttons and collapsible sidebar

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -19,9 +19,12 @@
     </aside>
     <!-- Main content area -->
     <main id="main">
-      <!-- Header with current analysis title and export/delete controls -->
+      <!-- Header with current analysis title, sidebar toggle and export/delete controls -->
       <header id="header">
-        <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        <div class="header-left">
+          <button id="sidebar-toggle" class="header-btn">☰</button>
+          <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        </div>
         <div class="header-buttons">
           <button id="export-btn" class="header-btn">Exporter</button>
           <button id="delete-btn" class="header-btn">Supprimer</button>

--- a/atelier2.html
+++ b/atelier2.html
@@ -18,9 +18,12 @@
       <input type="file" id="import-file" accept="application/json" style="display:none" />
     </aside>
     <main id="main">
-      <!-- Analysis title and controls -->
+      <!-- Analysis title, sidebar toggle and controls -->
       <header id="header">
-        <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        <div class="header-left">
+          <button id="sidebar-toggle" class="header-btn">☰</button>
+          <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        </div>
         <div class="header-buttons">
           <button id="export-btn" class="header-btn">Exporter</button>
           <button id="delete-btn" class="header-btn">Supprimer</button>

--- a/atelier3.html
+++ b/atelier3.html
@@ -18,9 +18,12 @@
       <input type="file" id="import-file" accept="application/json" style="display:none" />
     </aside>
     <main id="main">
-      <!-- Analysis title and controls -->
+      <!-- Analysis title, sidebar toggle and controls -->
       <header id="header">
-        <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        <div class="header-left">
+          <button id="sidebar-toggle" class="header-btn">☰</button>
+          <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        </div>
         <div class="header-buttons">
           <button id="export-btn" class="header-btn">Exporter</button>
           <button id="delete-btn" class="header-btn">Supprimer</button>

--- a/atelier4.html
+++ b/atelier4.html
@@ -18,9 +18,12 @@
       <input type="file" id="import-file" accept="application/json" style="display:none" />
     </aside>
     <main id="main">
-      <!-- Header with analysis title and actions -->
+      <!-- Header with analysis title, sidebar toggle and actions -->
       <header id="header">
-        <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        <div class="header-left">
+          <button id="sidebar-toggle" class="header-btn">☰</button>
+          <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        </div>
         <div class="header-buttons">
           <button id="export-btn" class="header-btn">Exporter</button>
           <button id="delete-btn" class="header-btn">Supprimer</button>

--- a/atelier5.html
+++ b/atelier5.html
@@ -18,9 +18,12 @@
       <input type="file" id="import-file" accept="application/json" style="display:none" />
     </aside>
     <main id="main">
-      <!-- Header with analysis title and export/delete buttons -->
+      <!-- Header with analysis title, sidebar toggle and export/delete buttons -->
       <header id="header">
-        <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        <div class="header-left">
+          <button id="sidebar-toggle" class="header-btn">☰</button>
+          <input id="analysis-title" type="text" placeholder="Titre de l'analyse" />
+        </div>
         <div class="header-buttons">
           <button id="export-btn" class="header-btn">Exporter</button>
           <button id="delete-btn" class="header-btn">Supprimer</button>
@@ -61,6 +64,9 @@
               </thead>
               <tbody id="gap-actions-body"></tbody>
             </table>
+          </div>
+          <div class="subtab-controls">
+            <button id="add-gap-action-row" class="add-item-btn">+ Ajouter une exigence personnalisée</button>
           </div>
         </div>
         <div id="atelier5-supports-tab" class="atelier5-subtab-content">
@@ -119,6 +125,9 @@
               </thead>
               <tbody id="risques-actions-body"></tbody>
             </table>
+          </div>
+          <div class="subtab-controls">
+            <button id="add-risque-action-row" class="add-item-btn">+ Ajouter un risque personnalisé</button>
           </div>
         </div>
         <div id="atelier5-plan-tab" class="atelier5-subtab-content">

--- a/styles.css
+++ b/styles.css
@@ -47,6 +47,20 @@ body, html {
   overflow-y: auto;
 }
 
+#sidebar.collapsed {
+  width: 0;
+  padding: 0;
+  border: none;
+  overflow: hidden;
+}
+
+#sidebar.collapsed .brand,
+#sidebar.collapsed .analysis-list,
+#sidebar.collapsed .sidebar-btn,
+#sidebar.collapsed #import-file {
+  display: none;
+}
+
 #sidebar .brand {
   font-size: 1.4rem;
   font-weight: bold;
@@ -123,9 +137,16 @@ body, html {
   border-bottom: 1px solid #0e1e37;
 }
 
-#header input[type="text"] {
+.header-left {
+  display: flex;
+  align-items: center;
   flex: 1;
+  gap: 0.5rem;
   margin-right: 1rem;
+}
+
+.header-left input[type="text"] {
+  flex: 1;
   padding: 0.6rem 0.8rem;
   background-color: var(--bg-panel);
   border: none;


### PR DESCRIPTION
## Summary
- allow adding custom GAP requirements and risks in Atelier 5
- preserve selected analysis when navigating between workshops
- toggle sidebar visibility to save space

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5bbd38d9c832fa63593a68c09640f