### PR TITLE
Persist analysis selection and shrink add buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -4987,5 +4987,9 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', init);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 })();

--- a/atelier4.html
+++ b/atelier4.html
@@ -88,7 +88,7 @@
       <input id="mitre-search" type="text" placeholder="Rechercher..." style="width:100%; margin-bottom:0.5rem;" />
       <ul id="mitre-list" class="risk-list"></ul>
       <div style="margin-top:0.6rem; display:flex; gap:0.5rem;">
-        <button id="mitre-import-apply" class="add-item-btn" style="flex:1;">Importer la sélection</button>
+        <button id="mitre-import-apply" class="add-item-btn">Importer la sélection</button>
         <button id="mitre-close-btn" class="header-btn" style="flex:1;">Fermer</button>
       </div>
     </div>
@@ -101,10 +101,10 @@
       <ul id="risk-list" class="risk-list"></ul>
       <div style="margin-top:0.6rem;">
         <input id="risk-manual" type="text" placeholder="Nom du risque personnalisé" style="width:100%; margin-bottom:0.4rem;" />
-        <button id="risk-add-manual" class="add-item-btn" style="width:100%">Ajouter ce risque</button>
+        <button id="risk-add-manual" class="add-item-btn">Ajouter ce risque</button>
       </div>
       <div style="margin-top:0.6rem; display:flex; gap:0.5rem;">
-        <button id="risk-select-apply" class="add-item-btn" style="flex:1;">Ajouter la sélection</button>
+        <button id="risk-select-apply" class="add-item-btn">Ajouter la sélection</button>
         <button id="risk-close-btn" class="header-btn" style="flex:1;">Fermer</button>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -285,6 +285,8 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
 }
 
 .add-item-btn {
+  display: inline-block;
+  width: auto;
   background-color: var(--bg-panel);
   border: 1px dashed var(--accent);
   color: var(--accent);


### PR DESCRIPTION
## Summary
- ensure previously selected analysis is restored on every page load
- make all “Ajouter” buttons use their natural width for consistent layout

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c8a44de4832f8594e8b2731d7d2f