### PR TITLE
Fix add button width in ateliers 1 and 4

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -287,6 +287,7 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
 .add-item-btn {
   display: inline-block;
   width: auto;
+  align-self: flex-start;
   background-color: var(--bg-panel);
   border: 1px dashed var(--accent);
   color: var(--accent);


### PR DESCRIPTION
## Summary
- prevent "Ajouter" buttons from stretching to full page width

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cc631c3c832f8396f145dcb8b92a