### PR TITLE
Retirer les options d'import de l'atelier 5

### DIFF
--- a/app.js
+++ b/app.js
@@ -1131,14 +1131,6 @@
   let importSelections = new Set();
 
   function setupActionImport() {
-    const btnGap = document.getElementById('import-gap-actions-btn');
-    if (btnGap) btnGap.addEventListener('click', () => openImportModal('gap'));
-    const btnSup = document.getElementById('import-supports-btn');
-    if (btnSup) btnSup.addEventListener('click', () => openImportModal('supports'));
-    const btnParties = document.getElementById('import-parties-btn');
-    if (btnParties) btnParties.addEventListener('click', () => openImportModal('parties'));
-    const btnRisques = document.getElementById('import-risques-btn');
-    if (btnRisques) btnRisques.addEventListener('click', () => openImportModal('risques'));
     const confirmBtn = document.getElementById('import-confirm');
     if (confirmBtn) confirmBtn.addEventListener('click', () => applyImportSelection());
     const cancelBtn = document.getElementById('import-cancel');

--- a/atelier5.html
+++ b/atelier5.html
@@ -44,16 +44,13 @@
         <div id="atelier5-subtabs" class="subtab-nav">
           <button class="atelier5-subtab-btn active" data-subtab="gap">Actions GAP</button>
           <button class="atelier5-subtab-btn" data-subtab="supports">Actions supports</button>
-          <button class="atelier5-subtab-btn" data-subtab="parties">Actions parties</button>
+          <button class="atelier5-subtab-btn" data-subtab="parties">Actions PP (Parties Prenantes)</button>
           <button class="atelier5-subtab-btn" data-subtab="risques">Actions risques</button>
           <button class="atelier5-subtab-btn" data-subtab="plan">Plan d'action</button>
         </div>
         <!-- Subtab content containers -->
         <div id="atelier5-gap-tab" class="atelier5-subtab-content active">
-          <p>Liste des exigences de conformité issues du GAP Analysis (non appliquées ou partiellement appliquées). Vous pouvez ajouter une ou plusieurs actions pour chaque exigence ou importer plusieurs exigences à traiter.</p>
-          <div class="subtab-controls">
-            <button id="import-gap-actions-btn" class="import-btn">Importer des exigences</button>
-          </div>
+          <p>Liste des exigences de conformité issues du GAP Analysis (non appliquées ou partiellement appliquées). Vous pouvez ajouter une ou plusieurs actions pour chaque exigence.</p>
           <div class="table-container">
             <table id="gap-actions-table" class="data-table">
               <thead>
@@ -101,16 +98,12 @@
               <tbody id="parties-actions-body"></tbody>
             </table>
             <div class="subtab-controls">
-              <button id="import-parties-btn" class="import-btn">Importer des parties</button>
               <button id="add-partie-action-row" class="add-item-btn">+ Ajouter une partie personnalisée</button>
             </div>
           </div>
         </div>
         <div id="atelier5-risques-tab" class="atelier5-subtab-content">
-          <p>Pour chaque risque identifié dans l’atelier 4, indiquez les actions de traitement, le niveau de vraisemblance actuel et le niveau résiduel souhaité. Vous pouvez également importer plusieurs risques à traiter.</p>
-          <div class="subtab-controls">
-            <button id="import-risques-btn" class="import-btn">Importer des risques</button>
-          </div>
+          <p>Pour chaque risque identifié dans l’atelier 4, indiquez les actions de traitement, le niveau de vraisemblance actuel et le niveau résiduel souhaité.</p>
           <div class="table-container">
             <table id="risques-actions-table" class="data-table">
               <thead>
@@ -151,7 +144,7 @@
             </table>
           </div>
         </div>
-        <!-- Modal for importing multiple items (supports, parties) -->
+        <!-- Modal for importing multiple items -->
         <div id="import-modal" class="modal" style="display:none;">
           <div class="modal-content">
             <h3 id="import-modal-title">Importer</h3>


### PR DESCRIPTION
## Summary
- Supprimer les boutons d'import des exigences, parties prenantes et risques sur l'atelier 5
- Renommer l'onglet "Actions parties" en "Actions PP (Parties Prenantes)"
- Nettoyer le script pour retirer les écouteurs liés aux imports supprimés

## Testing
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cce2b438832f91f7e8db6a28e40c