### PR TITLE
Persist analysis selection between workshops

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,19 @@
     try {
       const data = localStorage.getItem('ebiosAnalyses');
       analyses = data ? JSON.parse(data) : [];
+      // Ensure every analysis has a stable identifier for persistence.
+      // Older saved analyses may lack an `id` field, so assign one when
+      // loading and immediately save back to storage so future loads keep it.
+      let changed = false;
+      analyses.forEach(a => {
+        if (a && !a.id) {
+          a.id = uid();
+          changed = true;
+        }
+      });
+      if (changed) {
+        saveAnalyses();
+      }
     } catch (e) {
       console.warn('Failed to parse localStorage data, resetting.', e);
       analyses = [];
@@ -22,6 +35,20 @@
 
   function saveAnalyses() {
     localStorage.setItem('ebiosAnalyses', JSON.stringify(analyses));
+  }
+
+  // Persist the ID of the currently selected analysis in localStorage so
+  // that navigating between separate workshop pages restores the same
+  // analysis automatically.
+  function persistCurrentAnalysisId() {
+    try {
+      const sel = analyses[currentIndex];
+      if (sel && sel.id) {
+        localStorage.setItem('ebiosCurrentAnalysisId', sel.id);
+      }
+    } catch (e) {
+      // Ignore storage errors (e.g., private browsing)
+    }
   }
 
   // ----- Utility: generate a simple UID
@@ -56,17 +83,9 @@
 
   function selectAnalysis(index) {
     currentIndex = index;
-    // Persist the selected analysis ID so that navigation between pages
-    // retains the current analysis.  On load, init() will restore
-    // this selection based on the stored ID.
-    try {
-      const sel = analyses[index];
-      if (sel && sel.id) {
-        localStorage.setItem('ebiosCurrentAnalysisId', sel.id);
-      }
-    } catch (e) {
-      // ignore storage errors
-    }
+    // Persist selection so that changing workshops does not require the
+    // user to pick the analysis again.
+    persistCurrentAnalysisId();
     renderAnalysisList();
     const analysis = analyses[currentIndex];
     if (!analysis) return;
@@ -4745,12 +4764,7 @@
     tabs.forEach(btn => {
       // Anchors navigate to other pages; store current analysis before leaving
       if (btn.tagName && btn.tagName.toLowerCase() === 'a' && btn.hasAttribute('href')) {
-        btn.addEventListener('click', () => {
-          const cur = analyses[currentIndex];
-          if (cur && cur.id) {
-            try { localStorage.setItem('ebiosCurrentAnalysisId', cur.id); } catch (e) {}
-          }
-        });
+        btn.addEventListener('click', persistCurrentAnalysisId);
         return;
       }
       btn.addEventListener('click', () => {
@@ -4980,6 +4994,9 @@
     setupMitreImport();
     setupKillChainToggle();
       setupActionImport();
+    // Ensure the current analysis ID is saved even if the user reloads or
+    // closes the page without navigating through the provided links.
+    window.addEventListener('beforeunload', persistCurrentAnalysisId);
     // Select the previously selected analysis or the first one by default
     if (analyses.length > 0) {
       currentIndex = savedIndex >= 0 ? savedIndex : 0;


### PR DESCRIPTION
## Summary
- remember selected analysis across workshop pages by persisting its ID
- assign IDs to older analyses on load to preserve selection when switching pages
- centralize persistence logic and save the current selection on page unload

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd1afcc0832fa68bff274ee6e256