### PR TITLE
feat: track risk levels and keep sidebar closed

### DIFF
--- a/atelier4.html
+++ b/atelier4.html
@@ -50,13 +50,11 @@
                   <tr>
                     <th>Évènement</th>
                     <th>Chemin stratégique</th>
+                    <th>Risques</th>
                     <th><span class="col-title">Connaître</span> <span class="col-toggle" data-col="connaitre">👁️</span></th>
                     <th><span class="col-title">Rester</span> <span class="col-toggle" data-col="rester">👁️</span></th>
                     <th><span class="col-title">Trouver</span> <span class="col-toggle" data-col="trouver">👁️</span></th>
                     <th><span class="col-title">Exploiter</span> <span class="col-toggle" data-col="exploiter">👁️</span></th>
-                    <th>Risques</th>
-                    <th>Vraisemblance</th>
-                    <th>Gravité</th>
                     <th>Actions</th>
                   </tr>
                 </thead>

--- a/styles.css
+++ b/styles.css
@@ -997,8 +997,7 @@ canvas {
    2: Chemin stratégique,
    3-6: Kill chain phases (Connaître, Rester, Trouver, Exploiter),
    7: Risques,
-   8: Vraisemblance,
-   9: Gravité.
+   7: Exploiter.
    The last column (Actions) is not explicitly sized. */
 #ops-table th:nth-child(1),
 #ops-table td:nth-child(1) {
@@ -1009,42 +1008,35 @@ canvas {
   min-width: 200px;
 }
 #ops-table th:nth-child(3),
-#ops-table td:nth-child(3),
+#ops-table td:nth-child(3) {
+  min-width: 200px;
+}
 #ops-table th:nth-child(4),
 #ops-table td:nth-child(4),
 #ops-table th:nth-child(5),
 #ops-table td:nth-child(5),
 #ops-table th:nth-child(6),
-#ops-table td:nth-child(6) {
-  min-width: 180px;
-}
+#ops-table td:nth-child(6),
 #ops-table th:nth-child(7),
 #ops-table td:nth-child(7) {
-  min-width: 200px;
-}
-#ops-table th:nth-child(8),
-#ops-table td:nth-child(8),
-#ops-table th:nth-child(9),
-#ops-table td:nth-child(9) {
-  min-width: 80px;
-  text-align: center;
+  min-width: 180px;
 }
 
 /* Hide individual kill chain columns when corresponding class is set */
-#ops-table.hide-connaitre td:nth-child(3),
-#ops-table.hide-connaitre th:nth-child(3) .col-title {
+#ops-table.hide-connaitre td:nth-child(4),
+#ops-table.hide-connaitre th:nth-child(4) .col-title {
   display: none;
 }
-#ops-table.hide-rester td:nth-child(4),
-#ops-table.hide-rester th:nth-child(4) .col-title {
+#ops-table.hide-rester td:nth-child(5),
+#ops-table.hide-rester th:nth-child(5) .col-title {
   display: none;
 }
-#ops-table.hide-trouver td:nth-child(5),
-#ops-table.hide-trouver th:nth-child(5) .col-title {
+#ops-table.hide-trouver td:nth-child(6),
+#ops-table.hide-trouver th:nth-child(6) .col-title {
   display: none;
 }
-#ops-table.hide-exploiter td:nth-child(6),
-#ops-table.hide-exploiter th:nth-child(6) .col-title {
+#ops-table.hide-exploiter td:nth-child(7),
+#ops-table.hide-exploiter th:nth-child(7) .col-title {
   display: none;
 }
 
@@ -1052,6 +1044,9 @@ canvas {
 #ops-table select {
   width: 100%;
   box-sizing: border-box;
+}
+#ops-table .assoc-item select {
+  width: auto;
 }
 
 /* Column toggle icons */


### PR DESCRIPTION
## Summary
- move kill chain columns after risk details in atelier 4
- allow each risk to record its own likelihood and severity and update chart accordingly
- remember collapsed state of the sidebar across workshops

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ERM2/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b88892de68832f9c061dace3fd1647