### PR TITLE
Clarify risk metrics and preserve selections between workshops

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,8 @@
     try {
       const sel = analyses[currentIndex];
       if (sel && sel.id) {
+        // Save any pending changes and remember the current analysis
+        saveAnalyses();
         localStorage.setItem('ebiosCurrentAnalysisId', sel.id);
       }
     } catch (e) {
@@ -2971,6 +2973,10 @@
           const label = document.createElement('span');
           label.textContent = rk.name;
           tag.appendChild(label);
+          const vLabel = document.createElement('span');
+          vLabel.textContent = 'V:';
+          vLabel.title = 'Vraisemblance';
+          tag.appendChild(vLabel);
           const vSel = document.createElement('select');
           [1,2,3,4].forEach(v => {
             const o = document.createElement('option');
@@ -2987,6 +2993,10 @@
             updateAtelier4Chart();
           };
           tag.appendChild(vSel);
+          const gLabel = document.createElement('span');
+          gLabel.textContent = 'G:';
+          gLabel.title = 'Gravité';
+          tag.appendChild(gLabel);
           const gSel = document.createElement('select');
           [1,2,3,4].forEach(v => {
             const o = document.createElement('option');


### PR DESCRIPTION
## Summary
- Label risk properties in Atelier 4 so users can distinguish Vraisemblance and Gravité for each scenario risk.
- Save analyses when navigating between workshop pages to keep imported risk actions.

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b88af15de4832fbc8d97b5730f4728