### PR TITLE
Improve risk selection modal layout

### DIFF
--- a/atelier4.html
+++ b/atelier4.html
@@ -79,6 +79,11 @@
       <input id="risk-search" type="text" placeholder="Rechercher..." style="width:100%; margin-bottom:0.5rem;" />
       <div class="risk-table-container">
         <table id="risk-table" class="risk-table">
+          <colgroup>
+            <col class="col-id" />
+            <col class="col-name" />
+            <col class="col-desc" />
+          </colgroup>
           <thead>
             <tr><th>Technique ID</th><th>Technique Name</th><th>Technique Description</th></tr>
           </thead>

--- a/styles.css
+++ b/styles.css
@@ -803,6 +803,10 @@ canvas {
   overflow-y: auto;
   box-shadow: 0 4px 12px rgba(0,0,0,0.3);
 }
+#risk-modal .modal-content {
+  max-width: 900px;
+  width: 95%;
+}
 .modal-content h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
@@ -811,7 +815,7 @@ canvas {
 
 /* Risk selection table inside modal */
 .risk-table-container {
-  max-height: 300px;
+  max-height: 400px;
   overflow-y: auto;
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
@@ -825,12 +829,17 @@ canvas {
   top: 0;
   background: var(--bg-panel);
 }
+#risk-table col.col-id { width: 120px; }
+#risk-table col.col-name { width: 220px; }
+#risk-table col.col-desc { width: auto; }
 .risk-table th,
 .risk-table td {
   border: 1px solid var(--border-color);
   padding: 0.4rem 0.6rem;
   font-size: 0.9rem;
   color: var(--text-primary);
+  vertical-align: top;
+  word-break: break-word;
 }
 .risk-table tbody tr {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- enlarge risk selection modal for better readability
- display technique ID, name, and description in dedicated columns

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f365814832f923cda9e9393bdc9