### PR TITLE
feat: add dedicated vulnerability tab for support assets

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -41,10 +41,11 @@
       <!-- Atelier 1 : Mission et valeurs et GAP Analysis -->
       <section id="atelier1" class="tab-content active">
         <h2>Atelier 1 – Mission et valeurs</h2>
-        <!-- Sub‑tab navigation: mission/valeurs vs GAP analysis -->
+        <!-- Sub‑tab navigation: mission/valeurs, GAP analysis et vulnérabilités -->
         <div class="subtab-nav" id="atelier1-subtabs">
           <button class="atelier1-subtab-btn active" data-subtab="values">Mission & Valeurs</button>
           <button class="atelier1-subtab-btn" data-subtab="gap">GAP Analysis</button>
+          <button class="atelier1-subtab-btn" data-subtab="vuln">Vulnérabilité Bien support</button>
         </div>
         <!-- Graph area: network graph for mission/valeurs will appear here.  The
              GAP analysis diagram is drawn dynamically in the GAP tab. -->
@@ -76,6 +77,22 @@
                 <tbody id="missions-body"></tbody>
               </table>
               <button id="add-mission-btn" class="add-item-btn">+ Ajouter une valeur</button>
+            </div>
+            <div id="atelier1-vuln-tab" class="atelier1-subtab-content">
+              <h2>Vulnérabilité des biens supports</h2>
+              <p>Liste des biens supports et des vulnérabilités associées.</p>
+              <table id="supports-qualif-table" class="data-table">
+                <thead>
+                  <tr>
+                    <th>Bien support</th>
+                    <th>Description</th>
+                    <th>Vulnérabilités</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="supports-qualif-body"></tbody>
+              </table>
+              <button id="add-support-qualif-btn" class="add-item-btn">+ Ajouter un bien support</button>
             </div>
             <!-- Sub‑tab: GAP analysis -->
             <div id="atelier1-gap-tab" class="atelier1-subtab-content">

--- a/atelier5.html
+++ b/atelier5.html
@@ -68,11 +68,12 @@
           </div>
         </div>
         <div id="atelier5-supports-tab" class="atelier5-subtab-content">
-          <p>Sélectionnez un bien support et définissez une ou plusieurs actions de conformité pour celui-ci.</p>
+          <p>Importez des vulnérabilités de l’atelier 1 puis définissez des actions de conformité pour chaque couple vulnérabilité/support.</p>
           <div class="table-container">
             <table id="support-actions-table" class="data-table">
               <thead>
                 <tr>
+                  <th>Vulnérabilité</th>
                   <th>Bien support</th>
                   <th>Actions</th>
                   <th></th>
@@ -81,7 +82,8 @@
               <tbody id="support-actions-body"></tbody>
             </table>
             <div class="subtab-controls">
-              <button id="add-support-action-row" class="add-item-btn">+ Ajouter un support personnalisé</button>
+              <button id="import-vuln-support" class="add-item-btn">+ Importer des vulnérabilités de l'atelier 1</button>
+              <button id="add-support-action-row" class="add-item-btn">+ Ajouter un couple personnalisé</button>
             </div>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -517,6 +517,27 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
   min-width: 420px;
 }
 
+/* Vulnérabilités list within qualification table */
+.vuln-cell .vuln-item {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto auto;
+  gap: 0.3rem;
+  align-items: center;
+  margin-bottom: 0.3rem;
+}
+
+.vuln-cell .vuln-item textarea {
+  width: 100%;
+}
+
+.vuln-cell .vuln-item select {
+  width: 100%;
+}
+
+.vuln-cell .vuln-item button {
+  padding: 0 0.4rem;
+}
+
 /* Widen the events column for missions (6th column) */
 #missions-table th:nth-child(6),
 #missions-table td:nth-child(6) {


### PR DESCRIPTION
## Summary
- add third subtab in Atelier 1 for "Vulnérabilité des biens supports"
- link vulnerabilities to supports defined in Mission & Valeurs and hide graphs in new tab

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b946d6cb00832f9a1fd2795f5b6fbc