### PR TITLE
Consolidate support vulnerability table and fix support selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -379,17 +379,19 @@
       addExistingBtn.className = 'add-support-btn';
       addExistingBtn.textContent = '+ Support existant';
       addExistingBtn.addEventListener('click', () => {
-        // Collect all unique supports across missions
+        // Collect all unique supports across missions and vulnerability table
         const allSupports = [];
-        analysis.data.missions.forEach(m2 => {
-          (m2.supports || []).forEach(s => {
-            const name = (s.name || '').trim();
-            if (!name) return;
-            if (!allSupports.some(ss => ss.name === name)) {
-              allSupports.push({ name: name, description: s.description || '', responsable: s.responsable || '' });
-            }
-          });
+        const addUnique = (s) => {
+          const name = (s.name || '').trim();
+          if (!name) return;
+          if (!allSupports.some(ss => ss.name === name)) {
+            allSupports.push({ name: name, description: s.description || '', responsable: s.responsable || '' });
+          }
+        };
+        (analysis.data.missions || []).forEach(m2 => {
+          (m2.supports || []).forEach(addUnique);
         });
+        (analysis.data.supportsQualif || []).forEach(addUnique);
         // Exclude supports already associated with the current mission
         const currentNames = mission.supports.map(s => (s.name || '').trim());
         const available = allSupports.filter(s => !currentNames.includes(s.name));
@@ -596,7 +598,9 @@
         color = '#f4a261';
         break;
       case 'forte':
-        color = '#e76f51';
+      case 'fort':
+        color = '#8b0000';
+        selectEl.style.color = '#fff';
         break;
       case 'critique':
         color = '#000';
@@ -605,7 +609,7 @@
       default:
         selectEl.style.color = '';
     }
-    if (lvl !== 'critique') selectEl.style.color = '';
+    if (lvl !== 'critique' && lvl !== 'forte' && lvl !== 'fort') selectEl.style.color = '';
     selectEl.style.backgroundColor = color;
   }
 
@@ -4922,6 +4926,7 @@
         analysis.data.supportsQualif.push({ name:'', description:'', vulnerabilities: [] });
         saveAnalyses();
         renderSupportsQualifTable();
+        renderSupportActions();
       });
     }
     // GAP analysis: add new requirement

--- a/atelier1.html
+++ b/atelier1.html
@@ -78,35 +78,23 @@
               </table>
               <button id="add-mission-btn" class="add-item-btn">+ Ajouter une valeur</button>
 
-              <h2>Qualification des biens supports</h2>
-              <p>Liste des biens supports et des vulnérabilités associées.</p>
-              <table id="supports-qualif-table" class="data-table">
-                <thead>
-                  <tr>
-                    <th>Bien support</th>
-                    <th>Description</th>
-                    <th>Vulnérabilités</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="supports-qualif-body"></tbody>
-              </table>
-              <button id="add-support-qualif-btn" class="add-item-btn">+ Ajouter un bien support</button>
             </div>
             <div id="atelier1-vuln-tab" class="atelier1-subtab-content">
               <h2>Vulnérabilité des biens supports</h2>
               <p>Liste des biens supports et des vulnérabilités associées.</p>
-              <table id="supports-qualif-table" class="data-table">
-                <thead>
-                  <tr>
-                    <th>Bien support</th>
-                    <th>Description</th>
-                    <th>Vulnérabilités</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="supports-qualif-body"></tbody>
-              </table>
+              <div class="table-container" style="overflow-x:auto;">
+                <table id="supports-qualif-table" class="data-table">
+                  <thead>
+                    <tr>
+                      <th>Bien support</th>
+                      <th>Description</th>
+                      <th>Vulnérabilités</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="supports-qualif-body"></tbody>
+                </table>
+              </div>
               <button id="add-support-qualif-btn" class="add-item-btn">+ Ajouter un bien support</button>
             </div>
             <!-- Sub‑tab: GAP analysis -->


### PR DESCRIPTION
## Summary
- Remove duplicate support qualification table and show a single consolidated vulnerability table
- Collect existing supports from missions and vulnerability table when adding to a mission
- Color strong vulnerability level in dark red and keep support actions synced

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b950549bf8832fa792ac26b8874cc3