### PR TITLE
feat: add refresh for support vulnerabilities

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -78,35 +78,24 @@
               </table>
               <button id="add-mission-btn" class="add-item-btn">+ Ajouter une valeur</button>
 
-              <h2>Qualification des biens supports</h2>
-              <p>Liste des biens supports et des vulnérabilités associées.</p>
-              <table id="supports-qualif-table" class="data-table">
-                <thead>
-                  <tr>
-                    <th>Bien support</th>
-                    <th>Description</th>
-                    <th>Vulnérabilités</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="supports-qualif-body"></tbody>
-              </table>
-              <button id="add-support-qualif-btn" class="add-item-btn">+ Ajouter un bien support</button>
             </div>
             <div id="atelier1-vuln-tab" class="atelier1-subtab-content">
               <h2>Vulnérabilité des biens supports</h2>
               <p>Liste des biens supports et des vulnérabilités associées.</p>
-              <table id="supports-qualif-table" class="data-table">
-                <thead>
-                  <tr>
-                    <th>Bien support</th>
-                    <th>Description</th>
-                    <th>Vulnérabilités</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="supports-qualif-body"></tbody>
-              </table>
+              <div class="table-container" style="overflow-x:auto;">
+                <table id="supports-qualif-table" class="data-table">
+                  <thead>
+                    <tr>
+                      <th>Bien support</th>
+                      <th>Description</th>
+                      <th>Vulnérabilités</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="supports-qualif-body"></tbody>
+                </table>
+              </div>
+              <button id="refresh-support-qualif-btn" class="add-item-btn">Actualiser les biens supports</button>
               <button id="add-support-qualif-btn" class="add-item-btn">+ Ajouter un bien support</button>
             </div>
             <!-- Sub‑tab: GAP analysis -->


### PR DESCRIPTION
## Summary
- add refresh button to vulnerability support table to sync supports from mission/values
- persist imported supports automatically

## Testing
- `npm test` *(fails: npm not found)*
- `node --check app.js` *(fails: node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b950549bf8832fa792ac26b8874cc3