### PR TITLE
Fix support vulnerability handling and add residual level

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -88,6 +88,7 @@
                     <tr>
                       <th>Bien support</th>
                       <th>Description</th>
+                      <th>Responsable</th>
                       <th>Vulnérabilités</th>
                       <th>Actions</th>
                     </tr>

--- a/atelier5.html
+++ b/atelier5.html
@@ -75,6 +75,8 @@
                 <tr>
                   <th>Vulnérabilité</th>
                   <th>Bien support</th>
+                  <th>Niveau initial</th>
+                  <th>Niveau résiduel</th>
                   <th>Actions</th>
                   <th></th>
                 </tr>


### PR DESCRIPTION
## Summary
- prevent duplicate support entries when editing mission supports
- track a responsible for each support vulnerability
- import initial vulnerability levels into Atelier 5 and allow residual level input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b95a626dc8832f8819cffd59fdb9df