### PR TITLE
feat: add Gantt chart to atelier 5

### DIFF
--- a/app.js
+++ b/app.js
@@ -4359,8 +4359,8 @@
   // Aggregate all actions and render plan table + gantt chart
   function renderPlanActions() {
     const body = document.getElementById('plan-actions-body');
-    const canvas = document.getElementById('gantt-chart');
-    if (!body || !canvas) return;
+    const chartEl = document.getElementById('gantt-chart');
+    if (!body || !chartEl) return;
     body.innerHTML = '';
     const analysis = analyses[currentIndex];
     if (!analysis || !analysis.data) return;
@@ -4436,61 +4436,8 @@
     });
     addDataTableResizers('plan-actions-table');
     // Draw gantt chart
-    drawGanttChart(canvas, actions);
-  }
-
-  // Draw a simple Gantt chart on a canvas from a list of actions with start/end dates
-  function drawGanttChart(canvas, actions) {
-    const ctx = canvas.getContext('2d');
-    // Clear
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    if (!actions || actions.length === 0) return;
-    // Parse dates
-    const parsed = actions.map(act => {
-      const start = act.start ? new Date(act.start) : null;
-      const end = act.end ? new Date(act.end) : null;
-      return { act, start, end };
-    }).filter(item => item.start && item.end && !isNaN(item.start.getTime()) && !isNaN(item.end.getTime()));
-    if (parsed.length === 0) return;
-    // Determine min and max dates
-    let minDate = parsed[0].start;
-    let maxDate = parsed[0].end;
-    parsed.forEach(it => {
-      if (it.start < minDate) minDate = it.start;
-      if (it.end > maxDate) maxDate = it.end;
-    });
-    const range = maxDate - minDate;
-    const rowHeight = 18;
-    const yMargin = 20;
-    const xMargin = 60;
-    canvas.height = yMargin * 2 + rowHeight * parsed.length;
-    // Draw axes
-    ctx.strokeStyle = 'rgba(255,255,255,0.2)';
-    ctx.beginPath();
-    ctx.moveTo(xMargin, yMargin);
-    ctx.lineTo(xMargin, canvas.height - yMargin);
-    ctx.lineTo(canvas.width - 10, canvas.height - yMargin);
-    ctx.stroke();
-    parsed.forEach((item, index) => {
-      const x = xMargin + ((item.start - minDate) / range) * (canvas.width - xMargin - 20);
-      const w = ((item.end - item.start) / range) * (canvas.width - xMargin - 20);
-      const y = yMargin + index * rowHeight + 4;
-      ctx.fillStyle = 'rgba(77,163,255,0.6)';
-      ctx.fillRect(x, y, w, rowHeight - 8);
-      ctx.fillStyle = 'var(--text-primary)';
-      ctx.font = '12px sans-serif';
-      ctx.fillText(item.act.name, 2, y + rowHeight - 12);
-    });
-    // Draw date labels on x-axis
-    const tickCount = Math.min(6, parsed.length > 0 ? parsed.length + 1 : 1);
-    for (let i = 0; i < tickCount; i++) {
-      const t = minDate.getTime() + (range * i) / (tickCount - 1);
-      const date = new Date(t);
-      const x = xMargin + (i / (tickCount - 1)) * (canvas.width - xMargin - 20);
-      const label = date.toISOString().slice(0, 10);
-      ctx.fillStyle = 'var(--text-secondary)';
-      ctx.font = '10px sans-serif';
-      ctx.fillText(label, x - 20, canvas.height - 5);
+    if (typeof drawGanttChartSVG === 'function') {
+      drawGanttChartSVG(chartEl, actions);
     }
   }
 

--- a/atelier5.html
+++ b/atelier5.html
@@ -131,8 +131,24 @@
         </div>
         <div id="atelier5-plan-tab" class="atelier5-subtab-content">
           <p>Vue consolidée de toutes les actions définies. Le diagramme de Gantt ci-dessous permet de visualiser les périodes de mise en œuvre.</p>
-          <div class="chart-wrapper">
-            <canvas id="gantt-chart" width="800" height="300" class="chart-canvas"></canvas>
+          <div class="wrap">
+            <div class="card">
+              <div class="controls">
+                <span>Survolez une action pour voir la bulle.</span>
+                <div class="legend">
+                  <span><i style="background:var(--bar)"></i>Action</span>
+                  <span><i style="background:var(--today)"></i>Aujourd'hui</span>
+                </div>
+              </div>
+              <div id="gantt-chart" class="chart" aria-label="Diagramme de Gantt des actions de l'atelier 5"></div>
+            </div>
+          </div>
+          <div id="gantt-tooltip" class="tooltip" role="dialog" aria-live="polite">
+            <div class="title"></div>
+            <div class="row"><strong style="min-width:88px">Responsable:</strong><span class="resp"></span></div>
+            <div class="row"><strong style="min-width:88px">Debut:</strong><span class="deb"></span></div>
+            <div class="row"><strong style="min-width:88px">Fin:</strong><span class="fin"></span></div>
+            <div class="row" style="margin-top:6px"><span class="desc" style="color:#e5e7eb"></span></div>
           </div>
           <div class="table-container">
             <table id="plan-actions-table" class="data-table">
@@ -167,5 +183,6 @@
     </main>
   </div>
   <script src="app.js"></script>
+  <script src="gantt.js"></script>
 </body>
 </html>

--- a/gantt.js
+++ b/gantt.js
@@ -1,0 +1,157 @@
+// Gantt chart renderer for Atelier 5 plan tab
+function drawGanttChartSVG(container, actions) {
+  if (!container) return;
+  const tooltip = document.getElementById('gantt-tooltip');
+  container.innerHTML = '';
+  if (tooltip) tooltip.style.opacity = '0';
+  if (!actions || actions.length === 0) return;
+
+  const rowHeight = 34;
+  const rowGap = 10;
+  const leftPad = 160;
+  const rightPad = 24;
+  const topPad = 30;
+  const bottomPad = 30;
+
+  function parseDate(s){ const [y,m,d] = s.split('-').map(Number); return new Date(y, m-1, d); }
+  function formatDate(d){
+    const y = d.getFullYear();
+    const m = String(d.getMonth()+1).padStart(2,'0');
+    const day = String(d.getDate()).padStart(2,'0');
+    return `${y}-${m}-${day}`;
+  }
+  function daysBetween(a,b){ return Math.round((b - a) / 86400000); }
+
+  const actData = actions.map((a, idx) => ({
+    id: `A-${idx+1}`,
+    title: a.name || a.title || `Action ${idx+1}`,
+    start: a.start,
+    end: a.end,
+    responsable: a.responsable || '',
+    description: a.description || ''
+  })).filter(a => a.start && a.end);
+  if (actData.length === 0) return;
+
+  const dates = actData.flatMap(a => [parseDate(a.start), parseDate(a.end)]);
+  let minDate = new Date(Math.min(...dates.map(d=>d.getTime())));
+  let maxDate = new Date(Math.max(...dates.map(d=>d.getTime())));
+  const padDays = 1;
+  minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate()-padDays);
+  maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate()+padDays);
+
+  const totalDays = Math.max(1, daysBetween(minDate, maxDate));
+  const pxPerDay = 28;
+  const chartWidth = leftPad + rightPad + totalDays * pxPerDay;
+  const chartHeight = topPad + bottomPad + actData.length * (rowHeight + rowGap);
+
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS,'svg');
+  svg.setAttribute('width', chartWidth);
+  svg.setAttribute('height', chartHeight);
+  svg.setAttribute('role','img');
+  svg.setAttribute('aria-label','Diagramme de Gantt');
+
+  const grid = document.createElementNS(svgNS,'g'); grid.setAttribute('class','grid');
+  for(let i=0;i<=totalDays;i++){
+    const x = leftPad + i*pxPerDay + 0.5;
+    const l = document.createElementNS(svgNS,'line');
+    l.setAttribute('x1', x); l.setAttribute('y1', topPad);
+    l.setAttribute('x2', x); l.setAttribute('y2', chartHeight - bottomPad);
+    l.setAttribute('stroke-dasharray', i%7===0 ? '' : '2 4');
+    grid.appendChild(l);
+  }
+  svg.appendChild(grid);
+
+  const axis = document.createElementNS(svgNS,'g'); axis.setAttribute('class','axis');
+  for(let i=0;i<=totalDays;i++){
+    const d = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate()+i);
+    if(i % 2 === 0 || i===0 || i===totalDays){
+      const tx = document.createElementNS(svgNS,'text');
+      tx.setAttribute('x', leftPad + i*pxPerDay + 2);
+      tx.setAttribute('y', topPad - 8);
+      tx.textContent = formatDate(d);
+      axis.appendChild(tx);
+    }
+  }
+  svg.appendChild(axis);
+
+  const ylabels = document.createElementNS(svgNS,'g'); ylabels.setAttribute('class','ylabels');
+  actData.forEach((a, idx)=>{
+    const y = topPad + idx*(rowHeight+rowGap) + rowHeight/2 + 6;
+    const t = document.createElementNS(svgNS,'text');
+    t.setAttribute('x', leftPad - 8);
+    t.setAttribute('y', y);
+    t.setAttribute('text-anchor','end');
+    t.textContent = a.title;
+    ylabels.appendChild(t);
+  });
+  svg.appendChild(ylabels);
+
+  const today = new Date();
+  if(today >= minDate && today <= maxDate){
+    const x = leftPad + daysBetween(minDate, new Date(today.getFullYear(), today.getMonth(), today.getDate())) * pxPerDay + 0.5;
+    const tl = document.createElementNS(svgNS,'line');
+    tl.setAttribute('class','today-line');
+    tl.setAttribute('x1', x); tl.setAttribute('y1', topPad);
+    tl.setAttribute('x2', x); tl.setAttribute('y2', chartHeight - bottomPad);
+    svg.appendChild(tl);
+  }
+
+  const bars = document.createElementNS(svgNS,'g');
+  actData.forEach((a, idx)=>{
+    const start = parseDate(a.start);
+    const end = parseDate(a.end);
+    const x = leftPad + daysBetween(minDate, start) * pxPerDay;
+    const w = Math.max(pxPerDay* Math.max(1, daysBetween(start, end)+1) - 6, 8);
+    const y = topPad + idx*(rowHeight+rowGap) + 2;
+    const h = rowHeight - 4;
+
+    const r = document.createElementNS(svgNS,'rect');
+    r.setAttribute('class','bar');
+    r.setAttribute('x', x); r.setAttribute('y', y);
+    r.setAttribute('width', w); r.setAttribute('height', h);
+    r.setAttribute('data-title', a.title);
+    r.setAttribute('data-resp', a.responsable);
+    r.setAttribute('data-deb', a.start);
+    r.setAttribute('data-fin', a.end);
+    r.setAttribute('data-desc', a.description);
+
+    r.addEventListener('mouseenter', ev => showTip(ev, r));
+    r.addEventListener('mouseleave', hideTip);
+    r.addEventListener('mousemove', moveTip);
+
+    bars.appendChild(r);
+  });
+  svg.appendChild(bars);
+
+  container.appendChild(svg);
+
+  const sr = document.createElement('div');
+  sr.className = 'sr-only';
+  sr.textContent = `Diagramme de Gantt de ${actData.length} actions, du ${formatDate(minDate)} au ${formatDate(maxDate)}.`;
+  container.appendChild(sr);
+
+  function showTip(ev, el){
+    if (!tooltip) return;
+    tooltip.querySelector('.title').textContent = el.getAttribute('data-title') || '';
+    tooltip.querySelector('.resp').textContent  = el.getAttribute('data-resp') || '';
+    tooltip.querySelector('.deb').textContent   = el.getAttribute('data-deb') || '';
+    tooltip.querySelector('.fin').textContent   = el.getAttribute('data-fin') || '';
+    tooltip.querySelector('.desc').textContent  = el.getAttribute('data-desc') || '';
+    tooltip.style.opacity = '1';
+    moveTip(ev);
+  }
+  function moveTip(ev){
+    if (!tooltip) return;
+    const pad = 16;
+    const vw = window.innerWidth, vh = window.innerHeight;
+    const rect = tooltip.getBoundingClientRect();
+    let x = ev.clientX, y = ev.clientY;
+    if(x - rect.width/2 < pad) x = pad + rect.width/2;
+    if(x + rect.width/2 > vw - pad) x = vw - pad - rect.width/2;
+    if(y - rect.height - 16 < pad) tooltip.style.transform = 'translate(-50%, 12px)'; else tooltip.style.transform = 'translate(-50%, calc(-100% - 12px))';
+    tooltip.style.left = x + 'px';
+    tooltip.style.top  = y + 'px';
+  }
+  function hideTip(){ if (tooltip) tooltip.style.opacity = '0'; }
+}

--- a/styles.css
+++ b/styles.css
@@ -1157,3 +1157,141 @@ canvas {
   transform: translate(-50%, -12px);
   white-space: nowrap;
 }
+
+/* Gantt chart styles for Atelier 5 */
+:root {
+  --bg: #0f172a;
+  --panel: #111827;
+  --grid: #1f2937;
+  --axis: #9ca3af;
+  --bar: #3b82f6;
+  --bar-hover: #60a5fa;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --today: #ef4444;
+}
+
+.wrap {
+  max-width: 1100px;
+  margin: 24px auto;
+  padding: 16px;
+}
+
+.card {
+  background: linear-gradient(180deg, #0b1228, #0a0f1f);
+  border: 1px solid #0b1228;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  margin: 0 0 8px;
+}
+
+.legend {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.legend i {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  margin-right: 6px;
+}
+
+.chart {
+  width: 100%;
+  overflow: auto;
+  border: 1px solid #0b1228;
+  border-radius: 12px;
+  background: var(--panel);
+}
+
+svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.axis text {
+  fill: var(--axis);
+  font-size: 12px;
+}
+
+.grid line {
+  stroke: var(--grid);
+  stroke-width: 1;
+}
+
+.ylabels text {
+  fill: var(--text);
+  font-size: 12px;
+}
+
+.bar {
+  fill: var(--bar);
+  cursor: pointer;
+  rx: 6;
+  ry: 6;
+  transition: filter 0.15s, transform 0.15s;
+}
+
+.bar:hover {
+  fill: var(--bar-hover);
+  filter: brightness(1.05) drop-shadow(0 2px 6px rgba(59, 130, 246, 0.35));
+  transform: translateY(-1px);
+}
+
+.today-line {
+  stroke: var(--today);
+  stroke-width: 2;
+  stroke-dasharray: 4 4;
+}
+
+.tooltip {
+  position: fixed;
+  z-index: 50;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, calc(-100% - 12px));
+  background: #0b1228;
+  color: var(--text);
+  border: 1px solid #1f2a44;
+  border-radius: 12px;
+  padding: 10px 12px;
+  min-width: 220px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  transition: opacity 0.08s ease-out;
+}
+
+.tooltip .title {
+  font-weight: 600;
+  margin: 0 0 6px;
+}
+
+.tooltip .row {
+  display: flex;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- replace canvas placeholder with interactive Gantt diagram in atelier 5 plan tab
- add styles and SVG-based renderer for Gantt chart
- hook plan action rendering to new chart implementation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd801c8f1c832f89b47263756d2128