### PR TITLE
feat: add risk evolution chart

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@
   // ----- Data model and persistence
   let analyses = [];
   let currentIndex = -1;
+  let risquesChart;
 
   function loadAnalyses() {
     try {
@@ -4123,6 +4124,99 @@
   }
 
   // Render actions for risks: show each risk and allow adding actions and residual levels
+  function renderRisquesChart() {
+    const el = document.getElementById('risques-chart');
+    if (!el || typeof echarts === 'undefined') return;
+    if (!risquesChart) {
+      risquesChart = echarts.init(el);
+    }
+    const analysis = analyses[currentIndex];
+    if (!analysis || !analysis.data) {
+      risquesChart.clear();
+      return;
+    }
+    const riskMap = new Map();
+    (analysis.data.so || []).forEach(scenario => {
+      (scenario.risks || []).forEach(riskObj => {
+        const name = riskObj.name || '';
+        if (!name) return;
+        const cur = riskMap.get(name) || { name, vraisemblance: riskObj.vraisemblance || 1, gravite: riskObj.gravite || 1 };
+        cur.vraisemblance = Math.max(cur.vraisemblance, riskObj.vraisemblance || 1);
+        cur.gravite = Math.max(cur.gravite, riskObj.gravite || 1);
+        riskMap.set(name, cur);
+      });
+    });
+    const initData = [];
+    const residData = [];
+    const arrowData = [];
+    (analysis.data.actionsRisques || []).forEach(row => {
+      const risk = riskMap.get(row.riskName) || { name: row.riskName, vraisemblance: row.residualV || 1, gravite: row.residualG || 1 };
+      const initial = [risk.gravite, risk.vraisemblance];
+      const residual = [row.residualG || risk.gravite, row.residualV || risk.vraisemblance];
+      initData.push({ value: initial, name: row.riskName, description: '' });
+      residData.push({ value: residual, name: row.riskName, description: '' });
+      arrowData.push({ coords: [initial, residual] });
+    });
+    const option = {
+      tooltip: {
+        trigger: 'item',
+        formatter: function (params) {
+          if (params.seriesType === 'scatter') {
+            return `<strong>${params.data.name}</strong><br/>Gravité: ${params.data.value[0]}<br/>Vraisemblance: ${params.data.value[1]}`;
+          }
+          return '';
+        }
+      },
+      legend: {
+        data: ['Initial', 'Résiduel', '-->'],
+        bottom: 0,
+        selected: { '-->': true },
+        selectedMode: 'multiple'
+      },
+      xAxis: { name: 'Gravité', type: 'value', min: 0, max: 4 },
+      yAxis: { name: 'Vraisemblance', type: 'value', min: 0, max: 4 },
+      series: [
+        {
+          name: 'Initial',
+          type: 'scatter',
+          data: initData,
+          itemStyle: { color: 'blue' },
+          symbolSize: 20,
+          label: { show: true, formatter: '{b}', position: 'top', fontSize: 12, color: 'blue' }
+        },
+        {
+          name: 'Résiduel',
+          type: 'scatter',
+          data: residData,
+          itemStyle: { color: 'red' },
+          symbolSize: 15,
+          label: { show: true, formatter: '{b}', position: 'bottom', fontSize: 12, color: 'red' }
+        },
+        {
+          name: '-->',
+          type: 'lines',
+          coordinateSystem: 'cartesian2d',
+          data: arrowData,
+          lineStyle: { color: 'gray', width: 2, type: 'dotted', opacity: 1 },
+          effect: { show: true, symbol: 'arrow', color: 'gray', symbolSize: 10, trailLength: 0 }
+        }
+      ]
+    };
+    risquesChart.setOption(option);
+    risquesChart.off('legendselectchanged');
+    risquesChart.on('legendselectchanged', function (event) {
+      if (event.name === '-->') {
+        const sel = event.selected['-->'];
+        const opt = risquesChart.getOption();
+        const arrow = opt.series[2];
+        arrow.lineStyle.opacity = sel ? 1 : 0;
+        arrow.effect.show = sel;
+        risquesChart.setOption({ series: opt.series });
+      }
+    });
+  }
+
+  // Render actions for risks: show each risk and allow adding actions and residual levels
   function renderRisquesActions() {
     const body = document.getElementById('risques-actions-body');
     if (!body) return;
@@ -4183,6 +4277,7 @@
         row.residualV = parseInt(e.target.value, 10);
         e.target.style.backgroundColor = levelColor(row.residualV);
         saveAnalyses();
+        renderRisquesChart();
       });
       tdResVr.appendChild(selVr);
       tr.appendChild(tdResVr);
@@ -4202,6 +4297,7 @@
         row.residualG = parseInt(e.target.value, 10);
         e.target.style.backgroundColor = levelColor(row.residualG);
         saveAnalyses();
+        renderRisquesChart();
       });
       tdResGr.appendChild(selGr);
       tr.appendChild(tdResGr);
@@ -4354,6 +4450,7 @@
       body.appendChild(tr);
     });
     addDataTableResizers('risques-actions-table');
+    renderRisquesChart();
   }
 
   // Aggregate all actions and render plan table + gantt chart

--- a/atelier5.html
+++ b/atelier5.html
@@ -128,6 +128,7 @@
           <div class="subtab-controls">
             <button id="add-risque-action-row" class="add-item-btn">+ Importer des risques de l'atelier 4</button>
           </div>
+          <div id="risques-chart" style="width:100%;height:400px;margin-top:1rem;"></div>
         </div>
         <div id="atelier5-plan-tab" class="atelier5-subtab-content">
           <p>Vue consolidée de toutes les actions définies. Le diagramme de Gantt ci-dessous permet de visualiser les périodes de mise en œuvre.</p>
@@ -183,6 +184,7 @@
       </section>
     </main>
   </div>
+  <script src="echarts.min.js"></script>
   <script src="app.js"></script>
   <script src="gantt.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add ECharts scatter plot in Atelier 5 to show initial and residual risks with arrows
- expose risk evolution data from actions and allow axes to start at zero

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8f1309e8832fa0bbb513c8d34d01