### PR TITLE
chore: standardize chart containers

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -50,7 +50,7 @@
         <!-- Graph area: network graph for mission/valeurs will appear here.  The
              GAP analysis diagram is drawn dynamically in the GAP tab. -->
         <div class="chart-wrapper" style="margin-bottom:1rem; position: relative;">
-          <div id="atelier1-graph" style="width:100%;height:660px;"></div>
+          <div id="atelier1-graph" class="chart-canvas" style="height:660px;"></div>
         </div>
         <!-- Grid layout for mission description, values/supports and gap analysis -->
         <div class="atelier-grid">

--- a/atelier5.html
+++ b/atelier5.html
@@ -128,7 +128,9 @@
           <div class="subtab-controls">
             <button id="add-risque-action-row" class="add-item-btn">+ Importer des risques de l'atelier 4</button>
           </div>
-          <div id="risques-chart" style="width:100%;height:400px;margin-top:1rem;"></div>
+          <div class="chart-wrapper">
+            <div id="risques-chart" class="chart-canvas" style="height:400px;"></div>
+          </div>
         </div>
         <div id="atelier5-plan-tab" class="atelier5-subtab-content">
           <p>Vue consolidée de toutes les actions définies. Le diagramme de Gantt ci-dessous permet de visualiser les périodes de mise en œuvre.</p>

--- a/styles.css
+++ b/styles.css
@@ -642,6 +642,8 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  /* Allow the column to shrink when tables overflow so charts keep their width */
+  min-width: 0;
 }
 
 /* Chart container styling */
@@ -650,6 +652,8 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
   border-radius: var(--border-radius);
   padding: 1rem;
   overflow-x: auto;
+  /* Keep charts readable by preventing excessive shrinkage */
+  min-width: 350px;
 }
 
 /* Supports list inside missions */


### PR DESCRIPTION
## Summary
- prevent tables from shrinking adjacent charts by allowing left column to collapse
- enforce a minimum width for chart wrappers so graphs stay readable
- wrap Atelier 5 risk chart with the common chart-wrapper

## Testing
- `npx -y stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*
- `npx -y htmlhint atelier1.html atelier5.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd95876558832f9f24f6ba4eda7954