### PR TITLE
Reposition charts and unify styles across workshops

### DIFF
--- a/app.js
+++ b/app.js
@@ -4157,6 +4157,9 @@
       residData.push({ value: residual, name: row.riskName, description: '' });
       arrowData.push({ coords: [initial, residual] });
     });
+    const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
+    const danger = getComputedStyle(document.documentElement).getPropertyValue('--danger').trim();
+    const secondary = getComputedStyle(document.documentElement).getPropertyValue('--text-secondary').trim();
     const option = {
       tooltip: {
         trigger: 'item',
@@ -4180,25 +4183,25 @@
           name: 'Initial',
           type: 'scatter',
           data: initData,
-          itemStyle: { color: 'blue' },
+          itemStyle: { color: accent },
           symbolSize: 20,
-          label: { show: true, formatter: '{b}', position: 'top', fontSize: 12, color: 'blue' }
+          label: { show: true, formatter: '{b}', position: 'top', fontSize: 12, color: accent }
         },
         {
           name: 'Résiduel',
           type: 'scatter',
           data: residData,
-          itemStyle: { color: 'red' },
+          itemStyle: { color: danger },
           symbolSize: 15,
-          label: { show: true, formatter: '{b}', position: 'bottom', fontSize: 12, color: 'red' }
+          label: { show: true, formatter: '{b}', position: 'bottom', fontSize: 12, color: danger }
         },
         {
           name: '-->',
           type: 'lines',
           coordinateSystem: 'cartesian2d',
           data: arrowData,
-          lineStyle: { color: 'gray', width: 2, type: 'dotted', opacity: 1 },
-          effect: { show: true, symbol: 'arrow', color: 'gray', symbolSize: 10, trailLength: 0 }
+          lineStyle: { color: secondary, width: 2, type: 'dotted', opacity: 1 },
+          effect: { show: true, symbol: 'arrow', color: secondary, symbolSize: 10, trailLength: 0 }
         }
       ]
     };
@@ -4939,10 +4942,10 @@
     }
 
     function colorForFiabilite(v) {
-      if (v < 4) return '#d54e5a';
-      if (v < 5) return '#ee7b8b';
-      if (v < 7) return '#5bb8c0';
-      return '#3da2c7';
+      if (v < 4) return levelColor(4);
+      if (v < 5) return levelColor(3);
+      if (v < 7) return levelColor(2);
+      return levelColor(1);
     }
 
     function sizeForExposition(v) {
@@ -4983,6 +4986,7 @@
       (acc[d.zone] ||= []).push(d);
       return acc;
     }, {});
+    const borderColor = getComputedStyle(document.documentElement).getPropertyValue('--bg-dark').trim();
 
     Object.entries(byZone).forEach(([zone, items]) => {
       items.forEach((d, i) => {
@@ -4998,7 +5002,7 @@
         c.setAttribute('r', sizeForExposition(d.exposition));
         c.setAttribute('fill', colorForFiabilite(d.fiabilite));
         c.setAttribute('opacity', '0.95');
-        c.setAttribute('stroke', '#0b1220');
+        c.setAttribute('stroke', borderColor);
         c.setAttribute('stroke-opacity', '0.1');
         c.setAttribute('filter', 'url(#softShadow)');
 
@@ -5532,9 +5536,12 @@
         document.querySelectorAll('#atelier5 .atelier5-subtab-content').forEach(content => {
           content.classList.toggle('active', content.id === 'atelier5-' + target + '-tab');
         });
-        // When switching to the plan tab, refresh the plan view and gantt chart
+        // Refresh charts when switching tabs
         if (target === 'plan') {
           renderPlanActions();
+        }
+        if (target === 'risques') {
+          renderRisquesChart();
         }
       });
     });

--- a/atelier2.html
+++ b/atelier2.html
@@ -39,34 +39,30 @@
       </nav>
       <!-- Atelier 2 content: SROV table and graph -->
       <section id="atelier2" class="tab-content active">
-        <div class="atelier-grid">
-          <div class="left">
-            <h2>Atelier 2 – Sources et objectifs</h2>
-            <p>Définissez les couples source de risque / objectif visé. Pour chaque couple, précisez la motivation et les ressources de la source (valeurs de 1 à 4), la priorité de l’objectif (1 à 4), si le couple est retenu et la justification de l’exclusion le cas échéant. La pertinence est calculée automatiquement (motivation × ressources) et colorée selon son niveau.</p>
-            <div class="table-container" style="overflow-x:auto; margin-bottom:1rem;">
-              <table id="srov-table" class="data-table" style="min-width:100%;">
-                <thead>
-                  <tr>
-                    <th>Source de risque</th>
-                    <th>Objectif visé</th>
-                    <th>Motivation</th>
-                    <th>Ressources</th>
-                    <th>Pertinence</th>
-                    <th>Priorité</th>
-                    <th>Retenue</th>
-                    <th>Justification</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="srov-body"></tbody>
-              </table>
-            </div>
-            <button id="add-srov-btn" class="add-item-btn">+ Ajouter un couple</button>
-          </div>
-          <div class="chart-wrapper">
-            <canvas id="atelier2-chart" width="600" height="400" class="chart-canvas"></canvas>
-          </div>
+        <h2>Atelier 2 – Sources et objectifs</h2>
+        <p>Définissez les couples source de risque / objectif visé. Pour chaque couple, précisez la motivation et les ressources de la source (valeurs de 1 à 4), la priorité de l’objectif (1 à 4), si le couple est retenu et la justification de l’exclusion le cas échéant. La pertinence est calculée automatiquement (motivation × ressources) et colorée selon son niveau.</p>
+        <div class="chart-wrapper">
+          <canvas id="atelier2-chart" width="600" height="400" class="chart-canvas"></canvas>
         </div>
+        <div class="table-container" style="overflow-x:auto; margin-bottom:1rem;">
+          <table id="srov-table" class="data-table" style="min-width:100%;">
+            <thead>
+              <tr>
+                <th>Source de risque</th>
+                <th>Objectif visé</th>
+                <th>Motivation</th>
+                <th>Ressources</th>
+                <th>Pertinence</th>
+                <th>Priorité</th>
+                <th>Retenue</th>
+                <th>Justification</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="srov-body"></tbody>
+          </table>
+        </div>
+        <button id="add-srov-btn" class="add-item-btn">+ Ajouter un couple</button>
       </section>
     </main>
   </div>

--- a/atelier3.html
+++ b/atelier3.html
@@ -46,7 +46,7 @@
           <button class="atelier3-subtab-btn" data-subtab="strategies">Scénarios stratégiques</button>
         </div>
         <!-- Chart placed below the sub‑tab navigation and above the table -->
-        <div id="atelier3-chart-container-top" class="chart-wrapper">
+          <div id="atelier3-chart-container-top" class="chart-wrapper" style="max-width:700px; margin:0 auto;">
           <div id="atelier3-radar-wrapper" class="radar-board">
             <svg id="atelier3-radar" class="radar-canvas" viewBox="0 0 960 760" width="100%" height="auto">
               <defs>
@@ -72,20 +72,20 @@
               </g>
 
               <g id="radar-thresholds" opacity="0.95">
-                <circle cx="480" cy="360" r="245" class="radar-thick" stroke="#1fb5a5"></circle>
-                <circle cx="480" cy="360" r="205" class="radar-thick" stroke="#f4d34e"></circle>
-                <circle cx="480" cy="360" r="165" class="radar-thick" stroke="#e24b5b"></circle>
+              <circle cx="480" cy="360" r="245" class="radar-thick" stroke="var(--success)"></circle>
+              <circle cx="480" cy="360" r="205" class="radar-thick" stroke="var(--warning)"></circle>
+              <circle cx="480" cy="360" r="165" class="radar-thick" stroke="var(--danger)"></circle>
               </g>
 
               <rect x="180" y="80" width="300" height="210" class="radar-sector-box"/>
               <rect x="480" y="80" width="300" height="210" class="radar-sector-box" opacity="0.5"/>
               <rect x="180" y="470" width="300" height="180" class="radar-sector-box"/>
 
-              <text x="205" y="100" class="radar-sector-tag">Beneficiaires</text>
-              <text x="785" y="100" class="radar-sector-tag" text-anchor="end">Partenaires</text>
-              <text x="205" y="650" class="radar-sector-tag">Prestataires</text>
+                <text x="205" y="100" class="radar-sector-tag">Beneficiaires</text>
+                <text x="785" y="100" class="radar-sector-tag" text-anchor="end">Partenaires</text>
+                <text x="205" y="650" class="radar-sector-tag">Prestataires</text>
 
-              <circle cx="480" cy="360" r="14" fill="#2a74b9" filter="url(#softShadow)"></circle>
+              <circle cx="480" cy="360" r="14" fill="var(--accent)" filter="url(#softShadow)"></circle>
               <text x="480" y="360" class="radar-label" text-anchor="middle" dy="-18">Objet de l etude</text>
 
               <g id="radar-points"></g>

--- a/atelier4.html
+++ b/atelier4.html
@@ -39,35 +39,31 @@
       </nav>
       <!-- Atelier 4: Scénarios opérationnels -->
       <section id="atelier4" class="tab-content active">
-        <div class="atelier-grid">
-          <div class="left">
-            <h2>Atelier 4 – Scénarios opérationnels</h2>
-            <p>Pour chaque scénario opérationnel, reliez un <strong>évènement redouté</strong> à un <strong>chemin d’attaque stratégique</strong> issu de l’atelier 3, puis décrivez les étapes de la cyber kill chain (Connaître, Rester, Trouver, Exploiter). Vous pouvez associer un ou plusieurs risques à chaque scénario et préciser pour chacun la vraisemblance et la gravité (échelle 1 à 4).</p>
-            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.8rem;">
-              <div class="table-container" style="overflow-x:auto; flex:1;">
-              <table id="ops-table" class="data-table" style="min-width:100%;">
-                <thead>
-                  <tr>
-                    <th>Évènement</th>
-                    <th>Chemin stratégique</th>
-                    <th>Risques</th>
-                    <th><span class="col-title">Connaître</span> <span class="col-toggle" data-col="connaitre">👁️</span></th>
-                    <th><span class="col-title">Rester</span> <span class="col-toggle" data-col="rester">👁️</span></th>
-                    <th><span class="col-title">Trouver</span> <span class="col-toggle" data-col="trouver">👁️</span></th>
-                    <th><span class="col-title">Exploiter</span> <span class="col-toggle" data-col="exploiter">👁️</span></th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="ops-body"></tbody>
-              </table>
-              </div>
-            </div>
-            <button id="add-op-btn" class="add-item-btn">+ Ajouter un scénario opérationnel</button>
-          </div>
-          <div class="chart-wrapper">
-            <canvas id="atelier4-chart" width="600" height="400" class="chart-canvas"></canvas>
+        <h2>Atelier 4 – Scénarios opérationnels</h2>
+        <p>Pour chaque scénario opérationnel, reliez un <strong>évènement redouté</strong> à un <strong>chemin d’attaque stratégique</strong> issu de l’atelier 3, puis décrivez les étapes de la cyber kill chain (Connaître, Rester, Trouver, Exploiter). Vous pouvez associer un ou plusieurs risques à chaque scénario et préciser pour chacun la vraisemblance et la gravité (échelle 1 à 4).</p>
+        <div class="chart-wrapper">
+          <canvas id="atelier4-chart" width="600" height="400" class="chart-canvas"></canvas>
+        </div>
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.8rem;">
+          <div class="table-container" style="overflow-x:auto; flex:1;">
+          <table id="ops-table" class="data-table" style="min-width:100%;">
+            <thead>
+              <tr>
+                <th>Évènement</th>
+                <th>Chemin stratégique</th>
+                <th>Risques</th>
+                <th><span class="col-title">Connaître</span> <span class="col-toggle" data-col="connaitre">👁️</span></th>
+                <th><span class="col-title">Rester</span> <span class="col-toggle" data-col="rester">👁️</span></th>
+                <th><span class="col-title">Trouver</span> <span class="col-toggle" data-col="trouver">👁️</span></th>
+                <th><span class="col-title">Exploiter</span> <span class="col-toggle" data-col="exploiter">👁️</span></th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="ops-body"></tbody>
+          </table>
           </div>
         </div>
+        <button id="add-op-btn" class="add-item-btn">+ Ajouter un scénario opérationnel</button>
       </section>
     </main>
   </div>

--- a/atelier5.html
+++ b/atelier5.html
@@ -109,6 +109,9 @@
         </div>
         <div id="atelier5-risques-tab" class="atelier5-subtab-content">
           <p>Pour chaque risque identifié dans l’atelier 4, indiquez les actions de traitement, le niveau de vraisemblance actuel et le niveau résiduel souhaité.</p>
+          <div class="chart-wrapper">
+            <div id="risques-chart" class="chart-canvas" style="height:400px;"></div>
+          </div>
           <div class="table-container">
             <table id="risques-actions-table" class="data-table">
               <thead>
@@ -127,9 +130,6 @@
           </div>
           <div class="subtab-controls">
             <button id="add-risque-action-row" class="add-item-btn">+ Importer des risques de l'atelier 4</button>
-          </div>
-          <div class="chart-wrapper">
-            <div id="risques-chart" class="chart-canvas" style="height:400px;"></div>
           </div>
         </div>
         <div id="atelier5-plan-tab" class="atelier5-subtab-content">

--- a/styles.css
+++ b/styles.css
@@ -1101,15 +1101,17 @@ canvas {
 .radar-board {
   position: relative;
   padding: 18px;
+  max-width: 700px;
+  margin: 0 auto;
 }
 .radar-canvas {
   display: block;
   margin: 0 auto;
-  background: #ffffff;
+  background: var(--bg-panel);
 }
 .radar-label {
   font-size: 12px;
-  fill: #8a93a3;
+  fill: var(--text-secondary);
 }
 .radar-label.radar-small {
   font-size: 11px;
@@ -1124,20 +1126,20 @@ canvas {
   opacity: 0.85;
 }
 .radar-grid {
-  stroke: #dfe6ef;
+  stroke: var(--text-secondary);
 }
 .radar-cross {
-  stroke: #9fb3c8;
+  stroke: var(--accent);
   stroke-dasharray: 6 6;
 }
 .radar-sector-tag {
   font-size: 13px;
-  fill: #334155;
+  fill: var(--text-primary);
   font-weight: 600;
 }
 .radar-sector-box {
   fill: none;
-  stroke: #dfe6ef;
+  stroke: var(--text-secondary);
   stroke-width: 2;
   rx: 16;
   ry: 16;


### PR DESCRIPTION
## Summary
- Move workshop 2, 4, and risk actions graphs below their headings for a consistent layout
- Harmonize the Atelier 3 radar chart size and colors with the site theme
- Refresh and recolor the risk actions scatter plot when switching tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd987f10b4832fb9f4b58d80817fc1