### PR TITLE
Remove kill chain columns from atelier4 and fix risk import

### DIFF
--- a/app.js
+++ b/app.js
@@ -1309,17 +1309,6 @@
     return Array.from(map.values());
   }
 
-  // Setup individual column toggle icons for the kill chain columns
-  function setupColumnToggles() {
-    const table = document.getElementById('ops-table');
-    if (!table) return;
-    table.querySelectorAll('.col-toggle').forEach(icon => {
-      const col = icon.getAttribute('data-col');
-      icon.addEventListener('click', () => {
-        table.classList.toggle('hide-' + col);
-      });
-    });
-  }
 
   /*
    * ----- Import modal setup -----
@@ -1423,18 +1412,25 @@
         items.push({ id, label, desc: desc || '', extra: '' });
       });
     } else if (type === 'risques') {
-      // gather risks from risk list, falling back on indice or id if needed
+      // Gather risks from the global list and from operational scenarios
       const riskMap = new Map();
       (analysis.data.risques || []).forEach(riskObj => {
         const label = riskObj.libelle || riskObj.titre || riskObj.indice || riskObj.id || '';
         if (!label) return;
         const id = riskObj.id || label;
-        if (!riskMap.has(id)) {
-          const desc = riskObj.description || '';
-          riskMap.set(id, { id, label, desc });
-        }
+        const desc = riskObj.description || '';
+        riskMap.set(id, { id, label, desc });
       });
-      riskMap.forEach((obj) => {
+      (analysis.data.so || []).forEach(so => {
+        (so.risks || []).forEach(rk => {
+          const label = rk.name || rk.id;
+          if (!label) return;
+          const id = rk.id || rk.name;
+          const desc = rk.description || '';
+          if (!riskMap.has(id)) riskMap.set(id, { id, label, desc });
+        });
+      });
+      riskMap.forEach(obj => {
         items.push({ id: obj.id, label: obj.label, desc: obj.desc || '', extra: '' });
       });
     }
@@ -1561,6 +1557,17 @@
         current.vraisemblance = Math.max(current.vraisemblance, parseInt(riskObj.vraisemblance, 10) || 1);
         current.gravite = Math.max(current.gravite, parseInt(riskObj.gravite, 10) || 1);
         riskMap.set(id, current);
+      });
+      (analysis.data.so || []).forEach(so => {
+        (so.risks || []).forEach(rk => {
+          const label = rk.name || rk.id;
+          if (!label) return;
+          const id = rk.id || rk.name;
+          const current = riskMap.get(id) || { id, name: label, vraisemblance: parseInt(rk.vraisemblance, 10) || 1, gravite: parseInt(rk.gravite, 10) || 1 };
+          current.vraisemblance = Math.max(current.vraisemblance, parseInt(rk.vraisemblance, 10) || 1);
+          current.gravite = Math.max(current.gravite, parseInt(rk.gravite, 10) || 1);
+          riskMap.set(id, current);
+        });
       });
       importSelections.forEach(id => {
         const risk = riskMap.get(id);
@@ -3210,10 +3217,6 @@
         if (!item.id) item.id = uid();
         if (!item.eventId) item.eventId = '';
         if (!item.path) item.path = '';
-        if (!Array.isArray(item.connaitre)) item.connaitre = [];
-        if (!Array.isArray(item.rester)) item.rester = [];
-        if (!Array.isArray(item.trouver)) item.trouver = [];
-        if (!Array.isArray(item.exploiter)) item.exploiter = [];
         if (!Array.isArray(item.risks)) item.risks = [];
         const tr = document.createElement('tr');
         // Event select
@@ -3332,52 +3335,6 @@
         td.appendChild(riskCell);
         tr.appendChild(td);
 
-        // Helper to render kill chain stage cell
-        function renderStageCell(stageKey) {
-          const cell = document.createElement('td');
-          const wrapper = document.createElement('div');
-          wrapper.className = 'assoc-cell';
-          // remove existing
-          (item[stageKey] || []).forEach((step, sIdx) => {
-            const tag = document.createElement('span');
-            tag.className = 'assoc-item';
-            tag.textContent = step;
-            const rmBtn = document.createElement('button');
-            rmBtn.className = 'remove-assoc';
-            rmBtn.textContent = '×';
-            rmBtn.title = 'Retirer cette étape';
-            rmBtn.addEventListener('click', () => {
-              if (!confirm('Retirer cette étape ?')) return;
-              item[stageKey].splice(sIdx, 1);
-              saveAnalyses();
-              renderSO();
-            });
-            tag.appendChild(rmBtn);
-            wrapper.appendChild(tag);
-          });
-          const addBtn = document.createElement('button');
-          addBtn.className = 'add-assoc-btn';
-          addBtn.textContent = '+ Ajouter';
-          addBtn.addEventListener('click', () => {
-            const val = prompt('Décrire une étape pour « ' + stageKey + ' » :');
-            if (val) {
-              item[stageKey].push(val);
-              saveAnalyses();
-              renderSO();
-            }
-          });
-          wrapper.appendChild(addBtn);
-          cell.appendChild(wrapper);
-          return cell;
-        }
-        // Connaître
-        tr.appendChild(renderStageCell('connaitre'));
-        // Rester
-        tr.appendChild(renderStageCell('rester'));
-        // Trouver
-        tr.appendChild(renderStageCell('trouver'));
-        // Exploiter
-        tr.appendChild(renderStageCell('exploiter'));
         // Actions: delete
         td = document.createElement('td');
         const delBtn = document.createElement('button');
@@ -3405,10 +3362,6 @@
             id: uid(),
             eventId: '',
             path: '',
-            connaitre: [],
-            rester: [],
-            trouver: [],
-            exploiter: [],
             risks: []
           });
           saveAnalyses();
@@ -4169,6 +4122,17 @@
       cur.gravite = Math.max(cur.gravite, parseInt(riskObj.gravite, 10) || 1);
       riskMap.set(id, cur);
     });
+    (analysis.data.so || []).forEach(so => {
+      (so.risks || []).forEach(rk => {
+        const label = rk.name || rk.id;
+        if (!label) return;
+        const id = rk.id || rk.name;
+        const cur = riskMap.get(id) || { id, name: label, vraisemblance: parseInt(rk.vraisemblance, 10) || 1, gravite: parseInt(rk.gravite, 10) || 1 };
+        cur.vraisemblance = Math.max(cur.vraisemblance, parseInt(rk.vraisemblance, 10) || 1);
+        cur.gravite = Math.max(cur.gravite, parseInt(rk.gravite, 10) || 1);
+        riskMap.set(id, cur);
+      });
+    });
     const initData = [];
     const residData = [];
     const arrowData = [];
@@ -4256,7 +4220,7 @@
     const analysis = analyses[currentIndex];
     if (!analysis || !analysis.data) return;
     if (!Array.isArray(analysis.data.actionsRisques)) analysis.data.actionsRisques = [];
-    // Gather risks from operational scenarios (atelier 4) for reference
+    // Gather risks from analysis list and operational scenarios for reference
     const riskMap = new Map();
     (analysis.data.risques || []).forEach(riskObj => {
       const label = riskObj.libelle || riskObj.titre || riskObj.indice || riskObj.id || '';
@@ -4266,6 +4230,17 @@
       cur.vraisemblance = Math.max(cur.vraisemblance, parseInt(riskObj.vraisemblance, 10) || 1);
       cur.gravite = Math.max(cur.gravite, parseInt(riskObj.gravite, 10) || 1);
       riskMap.set(id, cur);
+    });
+    (analysis.data.so || []).forEach(so => {
+      (so.risks || []).forEach(rk => {
+        const label = rk.name || rk.id;
+        if (!label) return;
+        const id = rk.id || rk.name;
+        const cur = riskMap.get(id) || { id, name: label, vraisemblance: parseInt(rk.vraisemblance, 10) || 1, gravite: parseInt(rk.gravite, 10) || 1 };
+        cur.vraisemblance = Math.max(cur.vraisemblance, parseInt(rk.vraisemblance, 10) || 1);
+        cur.gravite = Math.max(cur.gravite, parseInt(rk.gravite, 10) || 1);
+        riskMap.set(id, cur);
+      });
     });
     analysis.data.actionsRisques.forEach(row => {
       if (!row.riskId && row.riskName) {
@@ -5631,8 +5606,7 @@
     setupNavigation();
     setupSidebarToggle();
     setupAddButtons();
-    setupColumnToggles();
-      setupActionImport();
+    setupActionImport();
     // Ensure the current analysis ID is saved even if the user reloads or
     // closes the page without navigating through the provided links.
     window.addEventListener('beforeunload', persistCurrentAnalysisId);

--- a/atelier4.html
+++ b/atelier4.html
@@ -40,7 +40,7 @@
       <!-- Atelier 4: Scénarios opérationnels -->
       <section id="atelier4" class="tab-content active">
         <h2>Atelier 4 – Scénarios opérationnels</h2>
-        <p>Pour chaque scénario opérationnel, reliez un <strong>évènement redouté</strong> à un <strong>chemin d’attaque stratégique</strong> issu de l’atelier 3, puis décrivez les étapes de la cyber kill chain (Connaître, Rester, Trouver, Exploiter). Vous pouvez associer un ou plusieurs risques à chaque scénario et préciser pour chacun la vraisemblance et la gravité (échelle 1 à 4).</p>
+        <p>Pour chaque scénario opérationnel, reliez un <strong>évènement redouté</strong> à un <strong>chemin d’attaque stratégique</strong> issu de l’atelier 3. Vous pouvez associer un ou plusieurs risques à chaque scénario et préciser pour chacun la vraisemblance et la gravité (échelle 1 à 4).</p>
         <div class="chart-wrapper">
           <canvas id="atelier4-chart" width="600" height="400" class="chart-canvas"></canvas>
         </div>
@@ -52,10 +52,6 @@
                 <th>Évènement</th>
                 <th>Chemin stratégique</th>
                 <th>Risques</th>
-                <th><span class="col-title">Connaître</span> <span class="col-toggle" data-col="connaitre">👁️</span></th>
-                <th><span class="col-title">Rester</span> <span class="col-toggle" data-col="rester">👁️</span></th>
-                <th><span class="col-title">Trouver</span> <span class="col-toggle" data-col="trouver">👁️</span></th>
-                <th><span class="col-title">Exploiter</span> <span class="col-toggle" data-col="exploiter">👁️</span></th>
                 <th>Actions</th>
               </tr>
             </thead>

--- a/styles.css
+++ b/styles.css
@@ -1041,9 +1041,7 @@ canvas {
 /* Widen key columns for readability.  Columns are:
    1: Évènement redouté,
    2: Chemin stratégique,
-   3-6: Kill chain phases (Connaître, Rester, Trouver, Exploiter),
-   7: Risques,
-   7: Exploiter.
+   3: Risques.
    The last column (Actions) is not explicitly sized. */
 #ops-table th:nth-child(1),
 #ops-table td:nth-child(1) {
@@ -1057,34 +1055,6 @@ canvas {
 #ops-table td:nth-child(3) {
   min-width: 200px;
 }
-#ops-table th:nth-child(4),
-#ops-table td:nth-child(4),
-#ops-table th:nth-child(5),
-#ops-table td:nth-child(5),
-#ops-table th:nth-child(6),
-#ops-table td:nth-child(6),
-#ops-table th:nth-child(7),
-#ops-table td:nth-child(7) {
-  min-width: 180px;
-}
-
-/* Hide individual kill chain columns when corresponding class is set */
-#ops-table.hide-connaitre td:nth-child(4),
-#ops-table.hide-connaitre th:nth-child(4) .col-title {
-  display: none;
-}
-#ops-table.hide-rester td:nth-child(5),
-#ops-table.hide-rester th:nth-child(5) .col-title {
-  display: none;
-}
-#ops-table.hide-trouver td:nth-child(6),
-#ops-table.hide-trouver th:nth-child(6) .col-title {
-  display: none;
-}
-#ops-table.hide-exploiter td:nth-child(7),
-#ops-table.hide-exploiter th:nth-child(7) .col-title {
-  display: none;
-}
 
 /* Make selects fill their cells in the operational scenarios table */
 #ops-table select {
@@ -1093,12 +1063,6 @@ canvas {
 }
 #ops-table .assoc-item select {
   width: auto;
-}
-
-/* Column toggle icons */
-.col-toggle {
-  cursor: pointer;
-  margin-left: 0.3rem;
 }
 
 /* Radar chart styles for Atelier 3 cartography */


### PR DESCRIPTION
## Summary
- Drop Connaître/Rester/Trouver/Exploiter columns from atelier 4 and simplify corresponding layout
- Build risk action import list from scenario risks so selections appear in atelier 5
- Update risk chart and actions to use combined risk data

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdebadcd74832f893336c7be2b7be5