### PR TITLE
fix: enable Gantt chart scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1159,7 +1159,7 @@ canvas {
 }
 
 .wrap {
-  width: 100vw;
+  width: 100%;
   margin: 0;
   padding: 12px;
 }
@@ -1197,9 +1197,10 @@ canvas {
 }
 
 .chart {
-  width: 100vw;
+  width: 100%;
   height: 70vh;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: auto;
   border: 1px solid #0b1228;
   border-radius: 12px;
   background: var(--panel);
@@ -1207,8 +1208,6 @@ canvas {
 
 svg {
   display: block;
-  width: 100%;
-  height: auto;
 }
 
 .axis text {


### PR DESCRIPTION
## Summary
- allow the Gantt chart container to scroll horizontally and vertically
- remove forced SVG scaling so all actions remain visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be01426aac832fa39c92b17bea4cf6