### PR TITLE
Add interactive value-support-event graph

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -72,6 +72,15 @@
                 </div>
                 <h2>Valeurs métier et biens supports</h2>
               <p>Chaque valeur métier comporte une dénomination, une nature (information, processus, fonction), une description, un responsable et des biens supports associés (nom, description, responsable). Chaque valeur peut également comporter un ou plusieurs évènements redoutés avec niveau et description des impacts.</p>
+              <div class="graph-wrapper">
+                <svg id="viz" viewBox="0 0 1100 560" preserveAspectRatio="xMidYMid meet"></svg>
+                <div class="tip" id="tip"></div>
+                <div class="graph-legend">
+                  <span><svg width="20" height="20"><circle cx="10" cy="10" r="8" fill="var(--neutral)"/></svg> Valeur métier</span>
+                  <span><svg width="20" height="20"><polygon points="10,2 17,6 17,14 10,18 3,14 3,6" fill="var(--neutral)"/></svg> Bien support</span>
+                  <span><svg width="20" height="20"><polygon points="4,4 4,16 16,10" fill="var(--neutral)"/></svg> Évènement redouté</span>
+                </div>
+              </div>
               <table id="missions-table" class="data-table">
                 <thead>
                   <tr>

--- a/atelier1_graph.css
+++ b/atelier1_graph.css
@@ -1,3 +1,11 @@
+:root {
+  --g1:#22c55e;
+  --g2:#eab308;
+  --g3:#f97316;
+  --g4:#ef4444;
+  --neutral:#6ea8fe;
+}
+
 .graph-wrapper {
   background:#0b1422;
   border:1px solid #203656;
@@ -51,5 +59,19 @@
   opacity:0;
   transform:translate(-50%,-120%);
   transition:opacity .12s;
+}
+
+.graph-legend {
+  display:flex;
+  gap:1rem;
+  justify-content:center;
+  margin-top:6px;
+  font-size:12px;
+}
+
+.graph-legend span {
+  display:flex;
+  align-items:center;
+  gap:4px;
 }
 


### PR DESCRIPTION
## Summary
- embed interactive dependency graph linking business values, supports and feared events with hover highlighting
- style graph with shared color variables and add legend for node shapes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be07ea96f4832f8e9f5192b25ae29a