### PR TITLE
Render Atelier 1 graph from table data

### DIFF
--- a/app.js
+++ b/app.js
@@ -1854,12 +1854,55 @@
     container.appendChild(legend);
   }
 
-  // ----- Atelier 1: Graph replaced by standalone script
+  // ----- Atelier 1: Graph -----
+  // Build nodes and links from missions/supports/events and forward them to
+  // the rendering helper defined in atelier1_graph.js.
   let atelier1Chart = null; // placeholder for backward compatibility
   function updateAtelier1Graph() {
-    // Rendering is handled in atelier1_graph.js
-    if (typeof renderAtelier1StaticGraph === 'function') {
-      renderAtelier1StaticGraph();
+    const analysis = analyses[currentIndex];
+    if (!analysis || !analysis.data) {
+      if (typeof renderAtelier1Graph === 'function') renderAtelier1Graph([], []);
+      return;
+    }
+
+    const nodes = [];
+    const links = [];
+    const supportMap = new Map();
+    const eventMap = new Map();
+
+    (analysis.data.missions || []).forEach(mission => {
+      if (!mission.id) mission.id = uid();
+      nodes.push({ id: mission.id, type: 'valeur', label: mission.denom || 'Valeur' });
+
+      (mission.supports || []).forEach(support => {
+        if (!support.id) support.id = uid();
+        if (!supportMap.has(support.id)) {
+          supportMap.set(support.id, true);
+          nodes.push({ id: support.id, type: 'support', label: support.name || 'Support' });
+        }
+        links.push({ id: `${mission.id}-${support.id}`, source: mission.id, target: support.id, weight: 1 });
+      });
+
+      const events = (analysis.data.events || []).filter(ev => ev.missionId === mission.id);
+      events.forEach(ev => {
+        if (!ev.id) ev.id = uid();
+        if (!eventMap.has(ev.id)) {
+          eventMap.set(ev.id, true);
+          nodes.push({
+            id: ev.id,
+            type: 'event',
+            label: ev.evenement || 'Évènement',
+            severity: parseInt(ev.impact, 10) || 0
+          });
+        }
+        (mission.supports || []).forEach(support => {
+          links.push({ id: `${support.id}-${ev.id}`, source: support.id, target: ev.id, weight: 1 });
+        });
+      });
+    });
+
+    if (typeof renderAtelier1Graph === 'function') {
+      renderAtelier1Graph(nodes, links);
     }
   }
 

--- a/atelier1_graph.css
+++ b/atelier1_graph.css
@@ -63,15 +63,17 @@
 
 .graph-legend {
   display:flex;
-  gap:1rem;
-  justify-content:center;
-  margin-top:6px;
-  font-size:12px;
+  align-items:center;
+  gap:0.75rem;
+  width:max-content;
+  margin:6px auto 0;
+  font-size:14px;
 }
 
 .graph-legend span {
   display:flex;
   align-items:center;
   gap:4px;
+  white-space:nowrap;
 }
 

--- a/atelier1_graph.js
+++ b/atelier1_graph.js
@@ -1,32 +1,13 @@
-function renderAtelier1StaticGraph() {
+// Render the Atelier 1 graph from provided nodes and links.  The previous
+// implementation only displayed a static example which did not reflect the
+// data entered in the table.  This function is now data‑driven so it can be
+// called with the current missions/supports/events extracted from the
+// application state.
+function renderAtelier1Graph(nodes = [], links = []) {
   const svg = document.getElementById('viz');
   const tip = document.getElementById('tip');
   if (!svg || !tip) return;
   svg.innerHTML = '';
-
-  const nodes = [
-    {id:'V1', type:'valeur', label:'Gestion RH'},
-    {id:'V2', type:'valeur', label:'Facturation'},
-    {id:'V3', type:'valeur', label:'Suivi Clients'},
-    {id:'S1', type:'support', label:'Base RH'},
-    {id:'S2', type:'support', label:'Serveur Finance'},
-    {id:'S3', type:'support', label:'CRM'},
-    {id:'E1', type:'event', label:'Fuite données', severity:4},
-    {id:'E2', type:'event', label:'Indispo appli', severity:3},
-    {id:'E3', type:'event', label:'Fraude paiement', severity:2},
-    {id:'E4', type:'event', label:'Erreur saisie', severity:1}
-  ];
-  const links = [
-    {id:'L1', source:'V1', target:'S1', weight:2},
-    {id:'L2', source:'V2', target:'S2', weight:3},
-    {id:'L3', source:'V3', target:'S3', weight:2},
-    {id:'L4', source:'S1', target:'E1', weight:1},
-    {id:'L5', source:'S1', target:'E2', weight:1},
-    {id:'L6', source:'S2', target:'E2', weight:2},
-    {id:'L7', source:'S2', target:'E3', weight:1},
-    {id:'L8', source:'S3', target:'E4', weight:1},
-    {id:'L9', source:'S3', target:'E1', weight:1}
-  ];
 
   const sevColor = s => ({1:'#22c55e',2:'#eab308',3:'#f97316',4:'#ef4444'}[s] || '#6ea8fe');
   const byId = Object.fromEntries(nodes.map(n => [n.id, n]));


### PR DESCRIPTION
## Summary
- Build nodes and links from missions, supports and events so Atelier 1 graph reflects table data
- Replace static graph renderer with data-driven version
- Improve graph legend layout and sizing

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bf10d98648832fb2b4e86591c186f4