### PR TITLE
Reduce Atelier 1 graph legend

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -76,9 +76,9 @@
                 <svg id="viz" viewBox="0 0 1100 560" preserveAspectRatio="xMidYMid meet"></svg>
                 <div class="tip" id="tip"></div>
                 <div class="graph-legend">
-                  <span><svg width="20" height="20"><circle cx="10" cy="10" r="8" fill="var(--neutral)"/></svg> Valeur métier</span>
-                  <span><svg width="20" height="20"><polygon points="10,2 17,6 17,14 10,18 3,14 3,6" fill="var(--neutral)"/></svg> Bien support</span>
-                  <span><svg width="20" height="20"><polygon points="4,4 4,16 16,10" fill="var(--neutral)"/></svg> Évènement redouté</span>
+                  <span><svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="8" fill="var(--neutral)"/></svg> Valeur métier</span>
+                  <span><svg viewBox="0 0 20 20"><polygon points="10,2 17,6 17,14 10,18 3,14 3,6" fill="var(--neutral)"/></svg> Bien support</span>
+                  <span><svg viewBox="0 0 20 20"><polygon points="4,4 4,16 16,10" fill="var(--neutral)"/></svg> Évènement redouté</span>
                 </div>
               </div>
               <table id="missions-table" class="data-table">

--- a/atelier1_graph.css
+++ b/atelier1_graph.css
@@ -61,13 +61,14 @@
   transition:opacity .12s;
 }
 
+/* Smaller legend placed below the graph */
 .graph-legend {
   display:flex;
   align-items:center;
-  gap:0.75rem;
+  gap:0.5rem;
   width:max-content;
-  margin:6px auto 0;
-  font-size:14px;
+  margin:4px auto 0;
+  font-size:12px;
 }
 
 .graph-legend span {
@@ -75,5 +76,11 @@
   align-items:center;
   gap:4px;
   white-space:nowrap;
+}
+
+/* Reduce the icon size inside the legend */
+.graph-legend svg {
+  width:14px;
+  height:14px;
 }
 

--- a/graph_atelier1.html
+++ b/graph_atelier1.html
@@ -12,15 +12,15 @@
   html,body{margin:0;background:var(--bg);color:var(--ink);font:14px system-ui,Segoe UI,Roboto,Arial,sans-serif}
   .wrap{max-width:1100px;margin:18px auto;padding:12px}
   h1{font-size:20px;margin:0 0 10px;color:var(--ink);text-align:center}
-  .legend{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;margin:10px 0 12px}
-  .legend .i{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--border);padding:6px 10px;border-radius:10px}
-  .legend .shape{display:inline-block;vertical-align:middle}
+  .legend{display:flex;gap:6px;flex-wrap:wrap;justify-content:center;margin:4px auto 0;font-size:12px}
+  .legend .i{display:flex;align-items:center;gap:6px;background:var(--panel);border:1px solid var(--border);padding:4px 6px;border-radius:8px}
+  .legend .shape{display:inline-block;vertical-align:middle;transform:scale(.8);transform-origin:center}
   .legend .circle{width:18px;height:18px;border-radius:50%;background:var(--neutral)}
   .legend .hex{width:0;height:0;border-left:10px solid transparent;border-right:10px solid transparent;position:relative}
   .legend .hex:before{content:"";position:absolute;left:-10px;top:-9px;border-left:10px solid transparent;border-right:10px solid transparent;border-bottom:9px solid var(--neutral)}
   .legend .hex:after{content:"";position:absolute;left:-10px;top:0;border-left:10px solid transparent;border-right:10px solid transparent;border-top:9px solid var(--neutral)}
   .legend .tri{width:0;height:0;border-top:10px solid transparent;border-bottom:10px solid transparent;border-left:18px solid var(--neutral)}
-  .legend .chip{width:12px;height:12px;border-radius:2px;display:inline-block}
+  .legend .chip{width:10px;height:10px;border-radius:2px;display:inline-block}
 
   .card{background:#0e1b2d;border:1px solid var(--border);border-radius:12px;padding:10px}
   svg{width:100%;height:560px;display:block;border-radius:10px}
@@ -44,23 +44,22 @@
 <div class="wrap">
   <h1>Chaîne de dépendance : Valeurs métier → Biens supports → Évènements redoutés</h1>
 
-  <!-- Petite légende des formes + rappel de la règle de couleur -->
-  <div class="legend">
-    <div class="i"><span class="shape circle"></span> Valeur métier (texte en dessous)</div>
-    <div class="i"><span class="shape hex"></span> Bien support (texte en dessous)</div>
-    <div class="i"><span class="shape tri"></span> Évènement (texte à droite)</div>
-    <div class="i">
-      <span>Couleur = gravité max connectée :</span>
-      <span class="chip" style="background:var(--g1)"></span> G1
-      <span class="chip" style="background:var(--g2)"></span> G2
-      <span class="chip" style="background:var(--g3)"></span> G3
-      <span class="chip" style="background:var(--g4)"></span> G4
-    </div>
-  </div>
-
   <div class="card">
     <svg id="viz" viewBox="0 0 1100 560" preserveAspectRatio="xMidYMid meet" aria-label="Graphe Atelier 1"></svg>
     <div class="tip" id="tip"></div>
+    <!-- Petite légende des formes + rappel de la règle de couleur -->
+    <div class="legend">
+      <div class="i"><span class="shape circle"></span> Valeur métier (texte en dessous)</div>
+      <div class="i"><span class="shape hex"></span> Bien support (texte en dessous)</div>
+      <div class="i"><span class="shape tri"></span> Évènement (texte à droite)</div>
+      <div class="i">
+        <span>Couleur = gravité max connectée :</span>
+        <span class="chip" style="background:var(--g1)"></span> G1
+        <span class="chip" style="background:var(--g2)"></span> G2
+        <span class="chip" style="background:var(--g3)"></span> G3
+        <span class="chip" style="background:var(--g4)"></span> G4
+      </div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Shrink Atelier 1 graph legend and icons so it occupies less space below the diagram
- Move and compact legend in standalone graph page

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bf129e8e5c832f9feab3d2b3075b33