### PR TITLE
feat: allow manual risk entry in workshop 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -1632,7 +1632,7 @@
     });
   }
 
-  // Open the risk modal and display MITRE techniques from the CSV
+  // Open the risk modal and display MITRE techniques from the CSV or allow manual entry
   function openRiskModal(targetItem) {
     riskModalTarget = targetItem;
     const modal = document.getElementById('risk-modal');
@@ -1642,6 +1642,9 @@
     const selectedDiv = document.getElementById('risk-selected');
     const closeBtn = document.getElementById('risk-close-btn');
     const applyBtn = document.getElementById('risk-select-apply');
+    const manualIdInput = document.getElementById('manual-risk-id');
+    const manualNameInput = document.getElementById('manual-risk-name');
+    const manualAddBtn = document.getElementById('manual-risk-add');
     let selectedIds = new Set();
 
     function renderTable(filter) {
@@ -1685,6 +1688,9 @@
       renderTable(e.target.value);
     };
 
+    if (manualIdInput) manualIdInput.value = '';
+    if (manualNameInput) manualNameInput.value = '';
+
     closeBtn.onclick = () => {
       closeRiskModal();
     };
@@ -1702,6 +1708,21 @@
         saveAnalyses();
         renderSO();
         closeRiskModal();
+      };
+    }
+
+    if (manualAddBtn) {
+      manualAddBtn.onclick = () => {
+        if (!riskModalTarget) return;
+        const id = manualIdInput ? manualIdInput.value.trim() : '';
+        const name = manualNameInput ? manualNameInput.value.trim() : '';
+        if (!name) return;
+        const label = id ? id + ' ' + name : name;
+        riskModalTarget.risks.push({ name: label, vraisemblance: 1, gravite: 1 });
+        saveAnalyses();
+        renderSO();
+        if (manualIdInput) manualIdInput.value = '';
+        if (manualNameInput) manualNameInput.value = '';
       };
     }
 

--- a/atelier4.html
+++ b/atelier4.html
@@ -64,11 +64,11 @@
     </main>
   </div>
   <script src="app.js"></script>
-  <!-- Modal for selecting risks from the MITRE CSV -->
+  <!-- Modal for selecting risks from the MITRE CSV or adding them manually -->
   <div id="risk-modal" class="modal" style="display:none">
     <div class="modal-content">
-      <h3>Ajouter un risque (MITRE)</h3>
-      <input id="risk-search" type="text" placeholder="Rechercher..." style="width:100%; margin-bottom:0.5rem;" />
+      <h3>Ajouter un risque</h3>
+      <input id="risk-search" type="text" placeholder="Rechercher dans la base MITRE..." style="width:100%; margin-bottom:0.5rem;" />
       <div class="risk-table-container">
         <table id="risk-table" class="risk-table">
           <colgroup>
@@ -83,6 +83,12 @@
         </table>
       </div>
       <div id="risk-selected" class="risk-selected"></div>
+      <!-- Manual risk entry -->
+      <div style="margin-top:0.6rem; display:flex; gap:0.5rem; flex-wrap:wrap;">
+        <input id="manual-risk-id" type="text" placeholder="ID" style="flex:0 0 6rem;" />
+        <input id="manual-risk-name" type="text" placeholder="Nom du risque" style="flex:1;" />
+        <button id="manual-risk-add" class="add-item-btn">Ajouter</button>
+      </div>
       <div style="margin-top:0.6rem; display:flex; gap:0.5rem;">
         <button id="risk-select-apply" class="add-item-btn">Ajouter la sélection</button>
         <button id="risk-close-btn" class="header-btn" style="flex:1;">Fermer</button>


### PR DESCRIPTION
## Summary
- allow manual risk input alongside MITRE CSV in workshop 4
- support new inputs in risk modal and JS handler

## Testing
- `node --check app.js`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &` (server started)
- `curl -I http://localhost:8000/mitre_attack.csv`


------
https://chatgpt.com/codex/tasks/task_e_68bf1d1af3b4832f83b09eb9091a68bd