### PR TITLE
Fix oversized legend for workshop 1 graph

### DIFF
--- a/atelier1.html
+++ b/atelier1.html
@@ -76,13 +76,13 @@
               <div id="atelier1-graph" class="graph-wrapper">
                 <svg id="viz" viewBox="0 0 1100 560" preserveAspectRatio="xMidYMid meet"></svg>
                 <div class="tip" id="tip"></div>
-                <div class="graph-legend">
-                  <span><svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="8" fill="var(--neutral)"/></svg> Valeur métier</span>
-                  <span><svg viewBox="0 0 20 20"><polygon points="10,2 17,6 17,14 10,18 3,14 3,6" fill="var(--neutral)"/></svg> Bien support</span>
-                  <span><svg viewBox="0 0 20 20"><polygon points="4,4 4,16 16,10" fill="var(--neutral)"/></svg> Évènement redouté</span>
+                  <div class="graph-legend">
+                    <span><svg viewBox="0 0 20 20" width="14" height="14"><circle cx="10" cy="10" r="8" fill="var(--neutral)"/></svg> Valeur métier</span>
+                    <span><svg viewBox="0 0 20 20" width="14" height="14"><polygon points="10,2 17,6 17,14 10,18 3,14 3,6" fill="var(--neutral)"/></svg> Bien support</span>
+                    <span><svg viewBox="0 0 20 20" width="14" height="14"><polygon points="4,4 4,16 16,10" fill="var(--neutral)"/></svg> Évènement redouté</span>
+                  </div>
                 </div>
-              </div>
-              <table id="missions-table" class="data-table">
+                <table id="missions-table" class="data-table">
                 <thead>
                   <tr>
                     <th>Dénomination</th>

--- a/atelier1_graph.css
+++ b/atelier1_graph.css
@@ -84,3 +84,14 @@
   height:14px;
 }
 
+@media print {
+  .graph-legend {
+    font-size:10px;
+  }
+
+  .graph-legend svg {
+    width:12px;
+    height:12px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Keep graph legend icons small by setting explicit width and height attributes.
- Add print-specific CSS to ensure legend stays compact when exporting pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c020399b70832f8c7e3f6da35c3ee2