### PR TITLE
Display severity level with event labels in workshop 3

### DIFF
--- a/app.js
+++ b/app.js
@@ -2762,7 +2762,10 @@
     const ppOptions = (analysis.data.ppc || []).map(pp => ({ value: pp.id, label: pp.nom || 'PP' }));
     // Build list of events (ER) from missions events
     const eventOptions = (analysis.data.events || []).map(ev => {
-      return { value: ev.id, label: ev.evenement || ev.ref || 'Évènement' };
+      const base = ev.evenement || ev.ref || 'Évènement';
+      const impact = parseInt(ev.impact, 10);
+      const sev = isNaN(impact) ? '' : ` (G${impact})`;
+      return { value: ev.id, label: base + sev };
     });
     // Helper to map impact level to color (1:green, 2:yellow, 3:orange, 4:red)
     const levelColor = (lvl) => {


### PR DESCRIPTION
## Summary
- Append gravité level to each event label when selecting feared events in atelier 3 strategic scenarios

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1396c326c832f8e54c28ee6a8ab8e