### PR TITLE
Make Atelier 1 graph scrollable for large datasets

### DIFF
--- a/atelier1_graph.css
+++ b/atelier1_graph.css
@@ -11,12 +11,14 @@
   border:1px solid #203656;
   border-radius:12px;
   padding:10px;
+  max-height:560px;
+  overflow:auto;
 }
 .graph-wrapper svg {
   width:100%;
-  height:560px;
   display:block;
   border-radius:10px;
+  min-height:560px;
 }
 .graph-wrapper .link {
   fill:none;

--- a/atelier1_graph.js
+++ b/atelier1_graph.js
@@ -9,6 +9,9 @@ function renderAtelier1Graph(nodes = [], links = []) {
   if (!svg || !tip) return;
   svg.innerHTML = '';
 
+  // Ensure the wrapper can scroll when the graph is tall
+  const wrapper = svg.closest('.graph-wrapper');
+
   const sevColor = s => ({1:'#22c55e',2:'#eab308',3:'#f97316',4:'#ef4444'}[s] || '#6ea8fe');
   const byId = Object.fromEntries(nodes.map(n => [n.id, n]));
   const outEdges = {}, inEdges = {};
@@ -39,9 +42,15 @@ function renderAtelier1Graph(nodes = [], links = []) {
     return '#6ea8fe';
   }
 
-  const X = {valeur:160, support:540, event:900}, groups = {valeur:[], support:[], event:[]};
+  const X = {valeur:160, support:540, event:900};
+  const groups = {valeur:[], support:[], event:[]};
   nodes.forEach(n => groups[n.type].push(n));
-  const top = 80, gap = 100;
+  const top = 80, gap = 80;
+  const maxRows = Math.max(groups.valeur.length, groups.support.length, groups.event.length, 1);
+  const height = top + (maxRows - 1) * gap + top;
+  svg.setAttribute('viewBox', `0 0 1040 ${height}`);
+  svg.style.height = height + 'px';
+  if (wrapper) wrapper.scrollTop = 0;
   Object.keys(groups).forEach(t => groups[t].forEach((n,i) => { n.x = X[t]; n.y = top + i * gap; }));
 
   const NS = 'http://www.w3.org/2000/svg';


### PR DESCRIPTION
## Summary
- Let the graph wrapper scroll and cap its height so large graphs remain usable
- Dynamically size the SVG based on node count

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16e7f2d70832fae7dc40a49595277