### PR TITLE
Ensure PDF export displays full text fields and tables

### DIFF
--- a/app.js
+++ b/app.js
@@ -5769,6 +5769,27 @@
                 valuesTab.appendChild(table2);
               }
             }
+            // Replace form fields with plain text so all text is visible and colours are kept
+            imported.querySelectorAll('input, textarea, select').forEach(field => {
+              const tag = field.tagName.toLowerCase();
+              const replacement = reportDoc.createElement(tag === 'textarea' ? 'div' : 'span');
+              replacement.className = field.className;
+              replacement.style.cssText = field.style.cssText;
+              if (tag === 'textarea') {
+                replacement.style.whiteSpace = 'pre-wrap';
+                replacement.textContent = field.value || field.textContent || '';
+              } else if (tag === 'select') {
+                const opt = field.options[field.selectedIndex];
+                replacement.textContent = opt ? opt.textContent : '';
+              } else {
+                replacement.textContent = field.value || field.textContent || '';
+              }
+              field.parentNode.replaceChild(replacement, field);
+            });
+            // Ensure tables are fully displayed
+            imported.querySelectorAll('table').forEach(tbl => {
+              tbl.style.width = '100%';
+            });
             imported.style.pageBreakAfter = 'always';
             targetBody.appendChild(imported);
           }


### PR DESCRIPTION
## Summary
- Replace form fields with plain text elements during PDF export to show all content and retain level colors
- Force tables to full width so they render completely in exported reports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1720a8d74832fa840c4131f6e2463