### PR TITLE
Ensure PDF export renders all tabs

### DIFF
--- a/app.js
+++ b/app.js
@@ -5631,9 +5631,31 @@
       iframe.onload = () => {
         setTimeout(() => {
           const doc = iframe.contentDocument;
+          const win = iframe.contentWindow;
           if (!doc) {
             document.body.removeChild(iframe);
             return resolve();
+          }
+          // Ensure that data for all sub‑tabs is rendered before we convert
+          // canvases to images and import the section into the report.
+          if (win) {
+            try {
+              if (page === 'atelier1.html') {
+                win.updateGapChart && win.updateGapChart();
+                win.renderSupportsQualifTable && win.renderSupportsQualifTable();
+              } else if (page === 'atelier3.html') {
+                win.updateAtelier3Chart && win.updateAtelier3Chart();
+              } else if (page === 'atelier5.html') {
+                win.renderGapActions && win.renderGapActions();
+                win.renderSupportActions && win.renderSupportActions();
+                win.renderPartiesActions && win.renderPartiesActions();
+                win.renderRisquesActions && win.renderRisquesActions();
+                win.renderPlanActions && win.renderPlanActions();
+                win.renderRisquesChart && win.renderRisquesChart();
+              }
+            } catch (e) {
+              // Ignore rendering errors; proceed with whatever content is available
+            }
           }
           doc.querySelectorAll('canvas').forEach(c => {
             const img = doc.createElement('img');


### PR DESCRIPTION
## Summary
- Render sub-tab content for all workshops prior to PDF export
- Convert canvases after rendering and include all action tables and charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c185a64058832f823eb96b640ede8c