### PR TITLE
Add import-all option to action selection modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1368,6 +1368,8 @@
     if (confirmBtn) confirmBtn.addEventListener('click', () => applyImportSelection());
     const cancelBtn = document.getElementById('import-cancel');
     if (cancelBtn) cancelBtn.addEventListener('click', () => closeImportModal());
+    const selectAllBtn = document.getElementById('import-select-all');
+    if (selectAllBtn) selectAllBtn.addEventListener('click', () => importAllVisibleItems());
     const searchInput = document.getElementById('import-search');
     if (searchInput) searchInput.addEventListener('input', () => filterImportList(searchInput.value));
   }
@@ -1555,6 +1557,23 @@
         div.style.display = 'none';
       }
     });
+  }
+
+  function importAllVisibleItems() {
+    const listEl = document.getElementById('import-list');
+    if (!listEl) return;
+    let hasVisible = false;
+    Array.from(listEl.children).forEach(div => {
+      if (div.style.display === 'none') return;
+      const id = div.dataset.id;
+      if (!id) return;
+      hasVisible = true;
+      importSelections.add(id);
+      div.classList.add('selected');
+    });
+    if (!hasVisible || !importSelections.size) return;
+    renderImportSelected();
+    applyImportSelection();
   }
 
   // Close modal without applying changes

--- a/atelier3.html
+++ b/atelier3.html
@@ -219,6 +219,7 @@
             <div id="import-list" style="max-height:300px; overflow-y:auto; border:1px solid var(--bg-panel); border-radius:4px; padding:4px;"></div>
             <div id="import-selected"></div>
             <div style="margin-top:0.5rem; display:flex; gap:0.5rem;">
+              <button id="import-select-all" class="add-item-btn" style="flex:1;">Tout importer</button>
               <button id="import-confirm" class="add-item-btn" style="flex:1;">Ajouter la sélection</button>
               <button id="import-cancel" class="header-btn" style="flex:1;">Fermer</button>
             </div>

--- a/atelier5.html
+++ b/atelier5.html
@@ -183,6 +183,7 @@
             <div id="import-list" style="max-height:300px; overflow-y:auto; border:1px solid var(--bg-panel); border-radius:4px; padding:4px;"></div>
             <div id="import-selected"></div>
             <div style="margin-top:0.5rem; display:flex; gap:0.5rem;">
+              <button id="import-select-all" class="add-item-btn" style="flex:1;">Tout importer</button>
               <button id="import-confirm" class="add-item-btn" style="flex:1;">Ajouter la sélection</button>
               <button id="import-cancel" class="header-btn" style="flex:1;">Fermer</button>
             </div>


### PR DESCRIPTION
## Summary
- add a "Tout importer" shortcut button to the shared multi-selection modal
- wire the new button so it selects every visible item and immediately applies the import

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc0625cda4832f95fd0a22727090af