### PR TITLE
Format risk identifiers in actions table

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,6 +222,15 @@
     return container;
   }
 
+  // Format a risk identifier by keeping only the characters before the first dash.
+  function formatRiskIdentifier(identifier) {
+    if (!identifier) return '';
+    const str = String(identifier).trim();
+    const dashIndex = str.search(/[-–—]/);
+    if (dashIndex === -1) return str;
+    return str.slice(0, dashIndex).trim();
+  }
+
   // ----- Atelier 1: Mission description
     function renderMissionDescription() {
       const textarea = document.getElementById('mission-description');
@@ -4218,8 +4227,10 @@
       const risk = riskMap.get(row.riskId) || { id: row.riskId, name: row.riskName, vraisemblance: row.residualV || 1, gravite: row.residualG || 1 };
       const initial = [risk.gravite, risk.vraisemblance];
       const residual = [row.residualG || risk.gravite, row.residualV || risk.vraisemblance];
-      initData.push({ value: initial, name: row.riskId || row.riskName, description: row.riskName || risk.name });
-      residData.push({ value: residual, name: row.riskId || row.riskName, description: row.riskName || risk.name });
+      const displayId = formatRiskIdentifier(row.riskId || '');
+      const label = displayId || row.riskName || risk.name;
+      initData.push({ value: initial, name: label, description: row.riskName || risk.name });
+      residData.push({ value: residual, name: label, description: row.riskName || risk.name });
       arrowData.push({ coords: [initial, residual] });
     });
     const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
@@ -4333,7 +4344,7 @@
         });
         tdId.appendChild(inpId);
       } else {
-        tdId.textContent = row.riskId || '';
+        tdId.textContent = formatRiskIdentifier(row.riskId || '');
       }
       tr.appendChild(tdId);
       const tdName = document.createElement('td');


### PR DESCRIPTION
## Summary
- add a helper to trim risk identifiers to the portion before the first dash
- use the trimmed identifier when rendering the actions table and risk chart labels

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc10878cd4832f916bf0258008482a