### PR TITLE
Aligner la cartographie des parties prenantes

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@
   let analyses = [];
   let currentIndex = -1;
   let risquesChart;
+  const RADAR_MAX_RADIUS = 260;
 
   function loadAnalyses() {
     try {
@@ -83,6 +84,22 @@
       case 4: return '#2a9d8f';
       default: return '#9aa0a6';
     }
+  }
+
+  // Determine the qualitative zone associated with a threat index.
+  function threatZoneMeta(indice) {
+    const value = Number.isFinite(indice) ? indice : 0;
+    if (value >= 3) return { key: 'danger', label: 'Zone de danger', bucket: 4 };
+    if (value >= 2) return { key: 'controle', label: 'Zone de contrôle', bucket: 3 };
+    if (value >= 1) return { key: 'veille', label: 'Zone de veille', bucket: 2 };
+    return { key: 'confiance', label: 'Zone de confiance', bucket: 1 };
+  }
+
+  function threatRadius(indice, maxR) {
+    const value = Math.max(0, Math.min(4, Number.isFinite(indice) ? indice : 0));
+    const outer = maxR * 0.88;
+    const inner = maxR * 0.28;
+    return outer - (outer - inner) * (value / 4);
   }
 
   // ----- Rendering functions
@@ -2708,9 +2725,9 @@
       td = document.createElement('td');
       td.className = 'expo-cell';
       tr.appendChild(td);
-      // Niveau SSI (computed)
+      // Fiabilité cyber (computed)
       td = document.createElement('td');
-      td.className = 'niveau-cell';
+      td.className = 'fiabilite-cell';
       tr.appendChild(td);
       // Indice de menace (computed)
       td = document.createElement('td');
@@ -2771,13 +2788,16 @@
         updateAtelier3Chart();
       };
     }
-    // Helper to update exposition, niveau SSI and indice cells
+    // Helper to update exposition, fiabilité et indice cells
     function updateDerivedCells(row, entry) {
       const expo = (entry.dependance || 1) * (entry.penetration || 1);
-      const niveau = (entry.maturite || 1) * (entry.confiance || 1);
-      const indice = niveau ? (expo / niveau) : 0;
+      const fiabilite = (entry.maturite || 1) * (entry.confiance || 1);
+      const indice = fiabilite ? (expo / fiabilite) : 0;
+      entry.exposition = expo;
+      entry.fiabilite = fiabilite;
+      entry.indiceMenace = indice;
       const expoCell = row.querySelector('.expo-cell');
-      const niveauCell = row.querySelector('.niveau-cell');
+      const fiabiliteCell = row.querySelector('.fiabilite-cell');
       const indiceCell = row.querySelector('.indice-cell');
       const coordCell = row.querySelector('.coord-cell');
       if (expoCell) {
@@ -2785,28 +2805,24 @@
         const bucket = pertinenceBucketForExpo(expo);
         expoCell.style.backgroundColor = levelColor(bucket);
       }
-      if (niveauCell) {
-        niveauCell.textContent = `${niveau}`;
-        const bucket = pertinenceBucketForExpo(niveau);
-        niveauCell.style.backgroundColor = ssiColor(bucket);
+      if (fiabiliteCell) {
+        fiabiliteCell.textContent = `${fiabilite}`;
+        const bucket = pertinenceBucketForExpo(fiabilite);
+        fiabiliteCell.style.backgroundColor = ssiColor(bucket);
       }
       if (indiceCell) {
         indiceCell.textContent = indice.toFixed(2);
-        // Colour based on indice: low values green, high values red
-        let indLvl;
-        if (indice >= 4) indLvl = 4;
-        else if (indice >= 3) indLvl = 3;
-        else if (indice >= 2) indLvl = 2;
-        else indLvl = 1;
-        indiceCell.style.backgroundColor = levelColor(indLvl);
+        const zone = threatZoneMeta(indice);
+        indiceCell.style.backgroundColor = levelColor(zone.bucket);
       }
       if (coordCell) {
-        const radius = Math.min(5, Math.max(1, Math.round((expo / 16) * 5)));
+        const zone = threatZoneMeta(indice);
         const angleMap = { partenaire: 0, beneficiaire: 90, interne: 180, autres: 180, prestataire: 270 };
         const angle = angleMap[entry.categorie] ?? 180;
-        coordCell.textContent = `${radius}, ${angle}°`;
-        entry.rayon = radius;
+        coordCell.textContent = `${zone.label} – ${angle}°`;
+        entry.rayon = threatRadius(indice, RADAR_MAX_RADIUS);
         entry.angle = angle;
+        entry.zoneMenace = zone.key;
       }
     }
     // Map exposition values to a bucket 1–4 similar to pertinence
@@ -5103,7 +5119,7 @@
     const pointsLayer = svg.querySelector('#radar-points');
     if (pointsLayer) pointsLayer.innerHTML = '';
     const center = { x: 480, y: 360 };
-    const maxR = 260;
+    const maxR = RADAR_MAX_RADIUS;
     const angleMap = { partenaire: 0, beneficiaire: 90, interne: 180, autres: 180, prestataire: 270 };
 
     function posFromPolar(r, deg) {
@@ -5115,21 +5131,39 @@
       return 4 + val * 2;
     }
 
-    const borderColor = getComputedStyle(document.documentElement).getPropertyValue('--bg-dark').trim();
+    const borderColor = getComputedStyle(document.documentElement).getPropertyValue('--bg-dark').trim() || '#0c1524';
+    tip.style.opacity = 0;
+    tip.innerHTML = '';
 
     ppc.forEach(item => {
       const dep = parseInt(item.dependance, 10) || 1;
       const pen = parseInt(item.penetration, 10) || 1;
       const mat = parseInt(item.maturite, 10) || 1;
       const conf = parseInt(item.confiance, 10) || 1;
-      const expo = dep * pen;
-      const radius = Math.min(5, Math.max(1, Math.round((expo / 16) * 5)));
+      const expoCandidate = (item.exposition !== undefined && item.exposition !== null && item.exposition !== '')
+        ? Number(item.exposition)
+        : NaN;
+      const fiabiliteCandidate = (item.fiabilite !== undefined && item.fiabilite !== null && item.fiabilite !== '')
+        ? Number(item.fiabilite)
+        : NaN;
+      const expo = Number.isFinite(expoCandidate) ? expoCandidate : (dep * pen);
+      const fiabilite = Number.isFinite(fiabiliteCandidate) ? fiabiliteCandidate : ((mat || 1) * (conf || 1));
+      const indiceCandidate = Number(item.indiceMenace);
+      const indice = Number.isFinite(indiceCandidate) ? indiceCandidate : (fiabilite ? expo / fiabilite : 0);
+      const zone = threatZoneMeta(indice);
       const angle = item.angle || angleMap[item.categorie] || 180;
       const colorLvl = Math.round((mat + conf) / 2);
-      const r = (radius / 5) * maxR;
-      const p = posFromPolar(r, angle);
+      const radialDistance = threatRadius(indice, maxR);
+      const p = posFromPolar(radialDistance, angle);
       const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
       g.setAttribute('class', 'radar-point');
+      g.dataset.zone = zone.key;
+      item.exposition = expo;
+      item.fiabilite = fiabilite;
+      item.indiceMenace = indice;
+      item.angle = angle;
+      item.rayon = radialDistance;
+      item.zoneMenace = zone.key;
 
       const c = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
       c.setAttribute('cx', p.x);
@@ -5138,7 +5172,8 @@
       c.setAttribute('fill', ssiColor(colorLvl));
       c.setAttribute('opacity', '0.95');
       c.setAttribute('stroke', borderColor);
-      c.setAttribute('stroke-opacity', '0.1');
+      c.setAttribute('stroke-opacity', '0.25');
+      c.setAttribute('stroke-width', '1.4');
       c.setAttribute('filter', 'url(#softShadow)');
 
       const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
@@ -5153,10 +5188,14 @@
 
       g.addEventListener('mousemove', (evt) => {
         const box = svg.getBoundingClientRect();
-        tip.style.left = (evt.clientX - box.left + 12) + 'px';
-        tip.style.top = (evt.clientY - box.top - 12) + 'px';
+        tip.style.left = (evt.clientX - box.left + 16) + 'px';
+        tip.style.top = (evt.clientY - box.top - 16) + 'px';
         tip.style.opacity = 1;
-        tip.textContent = `${item.nom || 'PP'} — r: ${radius} | angle: ${angle}°`;
+        tip.innerHTML = `<strong>${item.nom || 'PP'}</strong><br>` +
+          `Zone : ${zone.label}<br>` +
+          `Exposition : ${expo.toFixed(0)} – Fiabilité : ${fiabilite.toFixed(0)}<br>` +
+          `Indice de menace : ${indice.toFixed(2)}<br>` +
+          `Angle : ${angle}°`;
       });
       g.addEventListener('mouseleave', () => { tip.style.opacity = 0; });
     });

--- a/atelier3.html
+++ b/atelier3.html
@@ -77,26 +77,27 @@
                 </filter>
               </defs>
 
+              <g id="radar-zones" opacity="0.92">
+                <circle cx="480" cy="360" r="260" class="radar-zone zone-confiance"></circle>
+                <circle cx="480" cy="360" r="208" class="radar-zone zone-veille"></circle>
+                <circle cx="480" cy="360" r="156" class="radar-zone zone-controle"></circle>
+                <circle cx="480" cy="360" r="104" class="radar-zone zone-danger"></circle>
+              </g>
+
               <g id="radar-grid">
-                <circle cx="480" cy="360" r="260" class="radar-ring radar-grid"></circle>
-                <circle cx="480" cy="360" r="208" class="radar-ring radar-grid"></circle>
-                <circle cx="480" cy="360" r="156" class="radar-ring radar-grid"></circle>
-                <circle cx="480" cy="360" r="104" class="radar-ring radar-grid"></circle>
-                <circle cx="480" cy="360" r="52"  class="radar-ring radar-grid"></circle>
-                <text x="532" y="360" class="radar-label radar-small">1</text>
-                <text x="584" y="360" class="radar-label radar-small">2</text>
-                <text x="636" y="360" class="radar-label radar-small">3</text>
-                <text x="688" y="360" class="radar-label radar-small">4</text>
-                <text x="740" y="360" class="radar-label radar-small">5</text>
+                <circle cx="480" cy="360" r="260" class="radar-ring"></circle>
+                <circle cx="480" cy="360" r="208" class="radar-ring"></circle>
+                <circle cx="480" cy="360" r="156" class="radar-ring"></circle>
+                <circle cx="480" cy="360" r="104" class="radar-ring"></circle>
+                <circle cx="480" cy="360" r="52"  class="radar-ring"></circle>
                 <line x1="220" y1="360" x2="740" y2="360" class="radar-cross"/>
                 <line x1="480" y1="100" x2="480" y2="620" class="radar-cross"/>
               </g>
 
-              <g id="radar-thresholds" opacity="0.95">
-              <circle cx="480" cy="360" r="245" class="radar-thick" stroke="var(--success)"></circle>
-              <circle cx="480" cy="360" r="205" class="radar-thick" stroke="var(--warning)"></circle>
-              <circle cx="480" cy="360" r="165" class="radar-thick" stroke="var(--danger)"></circle>
-              </g>
+              <text x="480" y="92" class="radar-zone-label" text-anchor="middle">Zone de confiance</text>
+              <text x="480" y="154" class="radar-zone-label" text-anchor="middle">Zone de veille</text>
+              <text x="480" y="206" class="radar-zone-label" text-anchor="middle">Zone de contrôle</text>
+              <text x="480" y="258" class="radar-zone-label" text-anchor="middle">Zone de danger</text>
 
               <text x="480" y="80" class="radar-sector-tag" text-anchor="middle">Bénéficiaires</text>
               <text x="860" y="360" class="radar-sector-tag">Partenaires</text>
@@ -104,14 +105,14 @@
               <text x="100" y="360" class="radar-sector-tag" text-anchor="end">Interne/Autres</text>
 
               <circle cx="480" cy="360" r="14" fill="var(--accent)" filter="url(#softShadow)"></circle>
-              <text x="480" y="360" class="radar-label" text-anchor="middle" dy="-18">Objet de l etude</text>
+              <text x="480" y="360" class="radar-label" text-anchor="middle" dy="-18">Objet de l'étude</text>
 
             <g id="radar-points"></g>
           </svg>
           <div id="atelier3-radar-tooltip" class="radar-tooltip"></div>
           <div id="atelier3-radar-legend" class="radar-legend">
-            <div><strong>Couleur :</strong> confiance / maturité SSI (1 rouge → 4 vert)</div>
-            <div><strong>Cercles :</strong> exposition (1 centre → 5 périphérie)</div>
+            <div><strong>Couleur :</strong> niveau de fiabilité cyber (maturité & confiance de 1 = rouge à 4 = vert)</div>
+            <div><strong>Position radiale :</strong> indice de menace (zone de danger au centre → zone de confiance en périphérie)</div>
             <div><strong>Quadrants :</strong> partenaires (droite), bénéficiaires (haut), interne/autres (gauche), prestataires (bas)</div>
           </div>
         </div>
@@ -120,7 +121,7 @@
           <div class="left">
             <!-- Cartography sub‑tab -->
             <div id="atelier3-carto-tab" class="atelier3-subtab-content active">
-              <p>Cartographiez les parties prenantes : nom, catégorie (prestataire, partenaire, bénéficiaire), biens supports associés, valeurs métier associées, dépendance et pénétration (1 = vert à 4 = rouge), maturité SSI et confiance (1 = rouge à 4 = vert). Les champs exposition, niveau SSI et indice de menace sont calculés automatiquement.</p>
+              <p>Cartographiez les parties prenantes : nom, catégorie (prestataire, partenaire, bénéficiaire), biens supports associés, valeurs métier associées, dépendance et pénétration (1 = vert à 4 = rouge), maturité SSI et confiance (1 = rouge à 4 = vert). L’exposition (<em>dépendance × pénétration</em>), la fiabilité cyber (<em>maturité × confiance</em>) et l’indice de menace (<em>exposition ÷ fiabilité</em>) sont calculés automatiquement.</p>
               <div class="table-container" style="overflow-x:auto; margin-bottom:1rem;">
                 <table id="ppc-table" class="data-table" style="min-width:100%;">
                   <thead>
@@ -134,9 +135,9 @@
                       <th>Maturité SSI</th>
                       <th>Confiance</th>
                       <th>Exposition</th>
-                      <th>Niveau SSI</th>
+                      <th>Fiabilité cyber</th>
                       <th>Indice de menace</th>
-                      <th>Coordonnées</th>
+                      <th>Zone & angle</th>
                       <th>Actions</th>
                     </tr>
                   </thead>

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,10 @@
   --danger: #e74c3c;
   --success: #27ae60;
   --warning: #f39c12;
+  --zone-danger: rgba(230, 57, 70, 0.45);
+  --zone-controle: rgba(244, 162, 97, 0.35);
+  --zone-veille: rgba(42, 157, 143, 0.28);
+  --zone-confiance: rgba(56, 189, 248, 0.22);
   --border-radius: 4px;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
@@ -1086,19 +1090,28 @@ canvas {
 }
 .radar-ring {
   fill: none;
-  stroke-width: 2;
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 1.5;
 }
-.radar-thick {
-  fill: none;
-  stroke-width: 10;
-  opacity: 0.85;
+.radar-zone {
+  stroke: none;
+  pointer-events: none;
 }
-.radar-grid {
-  stroke: var(--text-secondary);
-}
+.zone-confiance { fill: var(--zone-confiance); }
+.zone-veille { fill: var(--zone-veille); }
+.zone-controle { fill: var(--zone-controle); }
+.zone-danger { fill: var(--zone-danger); }
 .radar-cross {
-  stroke: var(--accent);
+  stroke: rgba(77, 163, 255, 0.45);
   stroke-dasharray: 6 6;
+}
+.radar-zone-label {
+  fill: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  pointer-events: none;
 }
 .radar-sector-tag {
   font-size: 13px;
@@ -1129,7 +1142,9 @@ canvas {
   pointer-events: none;
   opacity: 0;
   transform: translate(-50%, -12px);
-  white-space: nowrap;
+  white-space: normal;
+  line-height: 1.4;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
 }
 
 .radar-legend {


### PR DESCRIPTION
## Summary
- Ajout des zones de menace et d’un libellé de légende cohérent avec l’atelier 3 sur la cartographie des parties prenantes.
- Calcul automatique de l’exposition, de la fiabilité cyber et de l’indice de menace pour piloter la position radiale et l’info-bulle du radar.
- Mise à jour du thème CSS pour représenter visuellement les zones de danger, contrôle, veille et confiance ainsi que la nouvelle info-bulle.

## Testing
- Manual UI testing

------
https://chatgpt.com/codex/tasks/task_e_68d55dc52138832f8e6d2e0e1d64bad9