### PR TITLE
feat: replace atelier 3 stakeholder diagram

### DIFF
--- a/atelier3.html
+++ b/atelier3.html
@@ -68,89 +68,168 @@
           <button class="atelier3-subtab-btn" data-subtab="strategies">Scénarios stratégiques</button>
         </div>
         <!-- Chart placed below the sub‑tab navigation and above the table -->
-          <div id="atelier3-chart-container-top" class="chart-wrapper">
-          <div id="atelier3-radar-wrapper" class="radar-board">
-            <svg id="atelier3-radar" class="radar-canvas" viewBox="0 0 960 760" width="100%" height="auto">
+          <div id="atelier3-chart-container-top" class="chart-wrapper stakeholder-wrapper">
+          <div id="atelier3-radar-wrapper" class="stakeholder-diagram" role="img" aria-label="Diagramme des parties prenantes de l'atelier 3">
+            <svg viewBox="0 0 1200 640">
+
+              <!-- MARKERS -->
               <defs>
-                <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-                  <feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#000" flood-opacity="0.1"/>
-                </filter>
+                <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 10,5 0,10Z" fill="#c0392b" />
+                </marker>
+                <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 10,5 0,10Z" fill="#3498db" />
+                </marker>
+                <marker id="arr-yellow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 10,5 0,10Z" fill="#f1c40f" />
+                </marker>
+                <marker id="arr-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 10,5 0,10Z" fill="#00c1b5" />
+                </marker>
+                <marker id="arr-grey" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 10,5 0,10Z" fill="#c0c6d0" />
+                </marker>
               </defs>
 
-              <g id="radar-zones" opacity="0.92">
-                <circle cx="480" cy="360" r="260" class="radar-zone zone-confiance"></circle>
-                <circle cx="480" cy="360" r="208" class="radar-zone zone-veille"></circle>
-                <circle cx="480" cy="360" r="156" class="radar-zone zone-controle"></circle>
-                <circle cx="480" cy="360" r="104" class="radar-zone zone-danger"></circle>
+              <!-- EN-TÊTES -->
+              <g class="label">
+                <rect class="pill" x="92" y="56" rx="16" ry="16" width="120" height="30"></rect>
+                <text class="tag" x="152" y="76" text-anchor="middle">CLIENTS</text>
+
+                <rect class="pill" x="92" y="236" rx="16" ry="16" width="155" height="30"></rect>
+                <text class="tag" x="169" y="256" text-anchor="middle">PRESTATAIRES</text>
+
+                <rect class="pill-blue" x="955" y="56" rx="16" ry="16" width="150" height="30"></rect>
+                <text class="tag" x="1030" y="76" text-anchor="middle">PARTENAIRES</text>
               </g>
 
-              <g id="radar-grid">
-                <circle cx="480" cy="360" r="260" class="radar-ring"></circle>
-                <circle cx="480" cy="360" r="208" class="radar-ring"></circle>
-                <circle cx="480" cy="360" r="156" class="radar-ring"></circle>
-                <circle cx="480" cy="360" r="104" class="radar-ring"></circle>
-                <circle cx="480" cy="360" r="52"  class="radar-ring"></circle>
-                <line x1="220" y1="360" x2="740" y2="360" class="radar-cross"/>
-                <line x1="480" y1="100" x2="480" y2="620" class="radar-cross"/>
+              <!-- LIBELLÉS GAUCHE -->
+              <g class="label">
+                <text x="64" y="116">C1 • Établissements de santé</text>
+                <text x="64" y="154">C2 • Pharmacies</text>
+                <text x="64" y="188">C3 • Dépositaires &amp; Grossistes réparateurs</text>
+
+                <text x="64" y="286">F3 • Prestataire informatique</text>
+                <text x="64" y="324">F2 • Fournisseurs de matériel</text>
+                <text x="64" y="356">F1 • Fournisseurs industriels chimistes</text>
               </g>
 
-              <text x="480" y="92" class="radar-zone-label" text-anchor="middle">Zone de confiance</text>
-              <text x="480" y="154" class="radar-zone-label" text-anchor="middle">Zone de veille</text>
-              <text x="480" y="206" class="radar-zone-label" text-anchor="middle">Zone de contrôle</text>
-              <text x="480" y="258" class="radar-zone-label" text-anchor="middle">Zone de danger</text>
-
-              <g class="radar-axis-guide">
-                <line x1="480" y1="360" x2="770" y2="360" class="radar-axis-line" />
-                <polygon points="770,360 752,348 752,372" class="radar-axis-arrowhead" />
-                <text x="776" y="356" class="radar-axis-zero">0</text>
-                <text x="776" y="376" class="radar-axis-caption">Niveau de menace</text>
+              <!-- LIBELLÉS DROITE -->
+              <g class="label">
+                <text x="935" y="140">P1 – Universités</text>
+                <text x="935" y="176">P2 – Régulateurs</text>
+                <text x="935" y="210">P3 – Laboratoires</text>
               </g>
 
-              <text x="480" y="80" class="radar-sector-tag" text-anchor="middle">Bénéficiaires</text>
-              <text x="860" y="360" class="radar-sector-tag">Partenaires</text>
-              <text x="480" y="700" class="radar-sector-tag" text-anchor="middle">Prestataires</text>
-              <text x="100" y="360" class="radar-sector-tag" text-anchor="end">Interne/Autres</text>
+              <!-- CIBLE -->
+              <g transform="translate(610,320)">
+                <g fill="none" stroke="#4c5563" stroke-width="1" stroke-dasharray="2 7" opacity=".7">
+                  <circle r="45" /><circle r="90" /><circle r="135" /><circle r="180" /><circle r="225" />
+                </g>
+                <g stroke="#7e8897" stroke-width="2" opacity=".85">
+                  <line x1="-245" y1="0" x2="245" y2="0" />
+                  <line x1="0" y1="-245" x2="0" y2="245" />
+                </g>
+                <circle r="262" fill="none" stroke="#39b54a" stroke-width="14" />
+                <circle r="216" fill="none" stroke="#f39c12" stroke-width="14" />
+                <circle r="156" fill="none" stroke="#e74c3c" stroke-width="14" />
+                <circle r="18" fill="#7fa3c6" opacity=".25" />
+                <circle r="8" fill="#7fa3c6" opacity=".55" />
 
-              <circle cx="480" cy="360" r="14" class="radar-origin"></circle>
-              <text x="480" y="360" class="radar-label" text-anchor="middle" dy="-18">Objet de l'étude</text>
+                <line x1="0" y1="0" x2="170" y2="152" stroke="#aeb8c6" stroke-width="10" marker-end="url(#arr-grey)" />
+                <polygon points="118,106 152,144 98,162" fill="#c8ced7" opacity=".9" />
+                <g transform="translate(212,194) rotate(40)">
+                  <ellipse rx="28" ry="18" fill="#1e88e5"></ellipse>
+                  <rect x="-8" y="-5" width="92" height="10" rx="5" fill="#5b6674"></rect>
+                </g>
 
-            <g id="radar-points"></g>
-          </svg>
-          <div id="atelier3-radar-tooltip" class="radar-tooltip"></div>
-          <div id="atelier3-radar-legend" class="radar-legend stakeholder-legend">
-            <div class="legend-block legend-block--zones">
-              <div class="legend-title">Lecture des zones</div>
-              <div class="legend-areas">
-                <span class="legend-chip chip-confiance">Zone de confiance</span>
-                <span class="legend-chip chip-veille">Zone de veille</span>
-                <span class="legend-chip chip-controle">Zone de contrôle</span>
-                <span class="legend-chip chip-danger">Zone de danger</span>
-              </div>
-              <div class="legend-text">Partenaires (droite) · Bénéficiaires (haut) · Prestataires (bas) · Interne/Autres (gauche)</div>
-            </div>
-            <div class="legend-block">
-              <div class="legend-title">Exposition</div>
-              <div class="legend-subtitle">Dépendance × Pénétration</div>
-              <div class="legend-scale">
-                <span class="legend-dot expo-1">1</span>
-                <span class="legend-dot expo-2">2</span>
-                <span class="legend-dot expo-3">3</span>
-                <span class="legend-dot expo-4">4</span>
-              </div>
-            </div>
-            <div class="legend-block">
-              <div class="legend-title">Fiabilité cyber</div>
-              <div class="legend-subtitle">Maturité SSI × Confiance</div>
-              <div class="legend-scale legend-scale--outline">
-                <span class="legend-dot rel-1">1</span>
-                <span class="legend-dot rel-2">2</span>
-                <span class="legend-dot rel-3">3</span>
-                <span class="legend-dot rel-4">4</span>
-              </div>
-            </div>
+                <g fill="#a8b2c3" font-size="12" text-anchor="middle">
+                  <text x="190" y="5">1</text><text x="150" y="5">2</text>
+                  <text x="110" y="5">3</text><text x="70" y="5">4</text>
+                  <text x="30" y="5">5</text><text x="-10" y="5">5</text>
+                </g>
+
+                <circle cx="-145" cy="-168" r="12" fill="#c62828" stroke="#5e0b0b" stroke-width="2" />
+                <circle cx="-190" cy="-64" r="11" fill="#29b6f6" stroke="#0b3a52" stroke-width="2" />
+                <circle cx="-205" cy="-18" r="12" fill="#1e88e5" stroke="#0b2a57" stroke-width="2" />
+
+                <circle cx="-96" cy="10" r="15" fill="#ffd21f" stroke="#7a5b00" stroke-width="2" />
+                <circle cx="-142" cy="88" r="18" fill="#1e88e5" stroke="#0b2a57" stroke-width="2" />
+                <circle cx="-84" cy="138" r="11" fill="#1e88e5" stroke="#0b2a57" stroke-width="2" />
+
+                <circle cx="132" cy="-132" r="12" fill="#c62828" stroke="#5e0b0b" stroke-width="2" />
+                <circle cx="100" cy="-150" r="11" fill="#00c1b5" stroke="#0a5954" stroke-width="2" />
+                <circle cx="74" cy="-70" r="12" fill="#ffd21f" stroke="#7a5b00" stroke-width="2" />
+              </g>
+
+              <!-- FLECHES GAUCHE -->
+              <g fill="none" stroke-width="2">
+                <line x1="328" y1="114" x2="458" y2="108" stroke="#c0392b" marker-end="url(#arr-red)" />
+                <line x1="290" y1="152" x2="398" y2="222" stroke="#3498db" marker-end="url(#arr-blue)" />
+                <line x1="324" y1="186" x2="402" y2="206" stroke="#3498db" marker-end="url(#arr-blue)" />
+
+                <line x1="322" y1="284" x2="470" y2="330" stroke="#f1c40f" marker-end="url(#arr-yellow)" />
+                <line x1="304" y1="322" x2="468" y2="374" stroke="#3498db" marker-end="url(#arr-blue)" />
+                <line x1="324" y1="354" x2="504" y2="414" stroke="#3498db" marker-end="url(#arr-blue)" />
+              </g>
+
+              <!-- FLECHES DROITE -->
+              <g fill="none" stroke-width="2">
+                <line x1="905" y1="138" x2="760" y2="120" stroke="#c0392b" marker-end="url(#arr-red)" />
+                <line x1="905" y1="174" x2="740" y2="116" stroke="#00c1b5" marker-end="url(#arr-cyan)" />
+                <line x1="905" y1="208" x2="760" y2="200" stroke="#f1c40f" marker-end="url(#arr-yellow)" />
+              </g>
+
+              <text x="812" y="324" fill="#a0acbd" font-size="12">Niveaux de menace</text>
+
+              <!-- LÉGENDE -->
+              <g transform="translate(890,352)">
+                <rect class="legendbox" width="280" height="210" rx="12" />
+                <g transform="translate(18,22)" fill="#e8ecf1">
+                  <text class="tag">EXPOSITION</text>
+                  <text class="small" y="18">= Dépendance × Pénétration</text>
+                  <g transform="translate(0,42)" fill="none" stroke="#e8ecf1" stroke-width="2">
+                    <circle cx="10" cy="8" r="5" /><circle cx="42" cy="8" r="8" /><circle cx="84" cy="8" r="11" /><circle cx="136" cy="8" r="14" />
+                  </g>
+                  <g transform="translate(0,42)" fill="#cfd6e3" class="small">
+                    <text x="0" y="32">&lt;3</text><text x="30" y="32">3-6</text><text x="72" y="32">7-9</text><text x="124" y="32">&gt;9</text>
+                  </g>
+
+                  <g transform="translate(0,104)" fill="#e8ecf1">
+                    <text class="tag">FIABILITÉ CYBER</text>
+                    <text class="small" y="18">= Maturité cyber × Confiance</text>
+                    <g transform="translate(0,34)">
+                      <circle cx="10" cy="6" r="6" fill="#c62828"></circle>
+                      <circle cx="42" cy="6" r="6" fill="#ffd21f"></circle>
+                      <circle cx="74" cy="6" r="6" fill="#1e88e5"></circle>
+                      <circle cx="106" cy="6" r="6" fill="#00c1b5"></circle>
+                      <text x="0" y="26" class="small" fill="#cfd6e3">&lt;4</text>
+                      <text x="32" y="26" class="small" fill="#cfd6e3">4-5</text>
+                      <text x="64" y="26" class="small" fill="#cfd6e3">6-7</text>
+                      <text x="96" y="26" class="small" fill="#cfd6e3">&gt;7</text>
+                    </g>
+                  </g>
+                </g>
+              </g>
+
+              <!-- BADGES ZONES -->
+              <g class="zoneBadge" transform="translate(470,598)" font-size="14" fill="#e8ecf1">
+                <g>
+                  <rect x="-12" y="-12" width="20" height="20" rx="4" fill="#39b54a" />
+                  <text x="16" y="0">Zone de veille</text>
+                </g>
+                <g transform="translate(168,0)">
+                  <rect x="-12" y="-12" width="20" height="20" rx="4" fill="#f39c12" />
+                  <text x="16" y="0">Zone de contrôle</text>
+                </g>
+                <g transform="translate(362,0)">
+                  <rect x="-12" y="-12" width="20" height="20" rx="4" fill="#e74c3c" />
+                  <text x="16" y="0">Zone de danger</text>
+                </g>
+              </g>
+            </svg>
           </div>
         </div>
-      </div>
         <div class="atelier-grid">
           <div class="left">
             <!-- Cartography sub‑tab -->

--- a/styles.css
+++ b/styles.css
@@ -675,6 +675,74 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
   position: relative;
 }
 
+#atelier3-chart-container-top.stakeholder-wrapper {
+  padding: 0;
+  background: none;
+  border: none;
+  max-width: 100%;
+  overflow: visible;
+  min-width: 0;
+  margin: 0 auto 1.5rem;
+}
+
+#atelier3-chart-container-top.stakeholder-wrapper::before,
+#atelier3-chart-container-top.stakeholder-wrapper::after {
+  display: none;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram {
+  background: #0b0f16;
+  border-radius: 18px;
+  border: 1px solid #1c2633;
+  box-shadow: 0 22px 36px rgba(0, 0, 0, 0.28);
+  padding: 1.5rem;
+  display: grid;
+  place-items: center;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram svg {
+  width: min(1200px, 96vw);
+  height: auto;
+  display: block;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .pill {
+  fill: #113018;
+  stroke: #2f6a37;
+  stroke-width: 1;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .pill-blue {
+  fill: #0e273a;
+  stroke: #2b5878;
+  stroke-width: 1;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .tag {
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  fill: #e8ecf1;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .label {
+  font-size: 15px;
+  fill: #d1d9e6;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .small {
+  font-size: 12px;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .legendbox {
+  fill: #0d121a;
+  stroke: #26303c;
+  stroke-width: 1;
+}
+
+#atelier3-radar-wrapper.stakeholder-diagram .zoneBadge text {
+  dominant-baseline: middle;
+}
+
 /* Supports list inside missions */
 .supports-list {
   display: flex;


### PR DESCRIPTION
## Summary
- swap the atelier 3 stakeholder chart for a static dark-themed SVG that mirrors the requested example, including category headers, arrows, and legend
- add dedicated styling so the new diagram fills the available width and matches the project palette

## Testing
- no automated tests were run (static markup change)


------
https://chatgpt.com/codex/tasks/task_e_68d684fe7c78832fbe8624a4403e8a51