### PR TITLE
Refactor Atelier 3 stakeholder cartography chart

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,6 @@
   let analyses = [];
   let currentIndex = -1;
   let risquesChart;
-  const RADAR_MAX_RADIUS = 260;
 
   function loadAnalyses() {
     try {
@@ -93,13 +92,6 @@
     if (value >= 2) return { key: 'controle', label: 'Zone de contrôle', bucket: 3 };
     if (value >= 1) return { key: 'veille', label: 'Zone de veille', bucket: 2 };
     return { key: 'confiance', label: 'Zone de confiance', bucket: 1 };
-  }
-
-  function threatRadius(indice, maxR) {
-    const value = Math.max(0, Math.min(4, Number.isFinite(indice) ? indice : 0));
-    const outer = maxR * 0.88;
-    const inner = maxR * 0.28;
-    return outer - (outer - inner) * (value / 4);
   }
 
   // ----- Rendering functions
@@ -2817,11 +2809,7 @@
       }
       if (coordCell) {
         const zone = threatZoneMeta(indice);
-        const angleMap = { partenaire: 0, beneficiaire: 90, interne: 180, autres: 180, prestataire: 270 };
-        const angle = angleMap[entry.categorie] ?? 180;
-        coordCell.textContent = `${zone.label} – ${angle}°`;
-        entry.rayon = threatRadius(indice, RADAR_MAX_RADIUS);
-        entry.angle = angle;
+        coordCell.textContent = `${zone.label} – Expo ${expo.toFixed(1)} / Fiab ${fiabilite.toFixed(1)}`;
         entry.zoneMenace = zone.key;
       }
     }
@@ -5117,23 +5105,86 @@
     const tip = document.getElementById('atelier3-radar-tooltip');
     if (!svg || !tip) return;
     const pointsLayer = svg.querySelector('#radar-points');
-    if (pointsLayer) pointsLayer.innerHTML = '';
-    const center = { x: 480, y: 360 };
-    const maxR = RADAR_MAX_RADIUS;
-    const angleMap = { partenaire: 0, beneficiaire: 90, interne: 180, autres: 180, prestataire: 270 };
+    const connectorsLayer = svg.querySelector('#radar-connectors');
+    const labelsLayer = svg.querySelector('#radar-labels');
+    if (!pointsLayer || !connectorsLayer || !labelsLayer) return;
 
-    function posFromPolar(r, deg) {
-      const rad = (deg - 90) * Math.PI / 180;
-      return { x: center.x + r * Math.cos(rad), y: center.y + r * Math.sin(rad) };
-    }
-    function sizeForDependance(v) {
-      const val = Math.max(1, Math.min(4, v));
-      return 6 + val * 3;
-    }
-
-    const borderColor = getComputedStyle(document.documentElement).getPropertyValue('--bg-dark').trim() || '#0c1524';
+    pointsLayer.innerHTML = '';
+    connectorsLayer.innerHTML = '';
+    labelsLayer.innerHTML = '';
     tip.style.opacity = 0;
+    tip.setAttribute('aria-hidden', 'true');
     tip.innerHTML = '';
+
+    const plot = {
+      x: Number(svg.getAttribute('data-plot-x')) || 230,
+      y: Number(svg.getAttribute('data-plot-y')) || 120,
+      width: Number(svg.getAttribute('data-plot-width')) || 500,
+      height: Number(svg.getAttribute('data-plot-height')) || 380
+    };
+    const centerX = plot.x + plot.width / 2;
+    const expoRange = { min: 0, max: 16 };
+    const fiabRange = { min: 0, max: 16 };
+    const categoryColours = {
+      partenaire: '#0ea5e9',
+      prestataire: '#f97316',
+      beneficiaire: '#22c55e',
+      interne: '#a855f7',
+      autres: '#94a3b8'
+    };
+    const categoryLabels = {
+      partenaire: 'Partenaire',
+      prestataire: 'Prestataire',
+      beneficiaire: 'Bénéficiaire',
+      interne: 'Interne',
+      autres: 'Autre'
+    };
+
+    const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+    const normalise = (value, range) => {
+      const numeric = Number(value);
+      const safe = Number.isFinite(numeric) ? numeric : range.min;
+      const clamped = clamp(safe, range.min, range.max);
+      return (clamped - range.min) / (range.max - range.min || 1);
+    };
+    const scaleX = (fiabilite) => plot.x + normalise(fiabilite, fiabRange) * plot.width;
+    const scaleY = (expo) => plot.y + plot.height - normalise(expo, expoRange) * plot.height;
+    const sizeForDependance = (v) => {
+      const val = Math.max(1, Math.min(4, v));
+      return 8 + val * 3;
+    };
+
+    const avoidOverlap = (x, y, r, placed) => {
+      let px = x;
+      let py = y;
+      const maxAttempts = 80;
+      const step = Math.max(6, r * 0.8);
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        let collides = false;
+        for (const other of placed) {
+          const dx = px - other.x;
+          const dy = py - other.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < r + other.r + 6) {
+            collides = true;
+            break;
+          }
+        }
+        if (!collides) {
+          return { x: px, y: py };
+        }
+        const angle = (attempt % 12) * (Math.PI / 6);
+        const radius = step * (1 + Math.floor(attempt / 12));
+        px = clamp(x + Math.cos(angle) * radius, plot.x + r, plot.x + plot.width - r);
+        py = clamp(y + Math.sin(angle) * radius, plot.y + r, plot.y + plot.height - r);
+      }
+      return { x: px, y: py };
+    };
+
+    const placedPoints = [];
+    const computedPoints = [];
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
 
     ppc.forEach(item => {
       const dep = parseInt(item.dependance, 10) || 1;
@@ -5151,54 +5202,153 @@
       const indiceCandidate = Number(item.indiceMenace);
       const indice = Number.isFinite(indiceCandidate) ? indiceCandidate : (fiabilite ? expo / fiabilite : 0);
       const zone = threatZoneMeta(indice);
-      const angle = item.angle || angleMap[item.categorie] || 180;
       const colorLvl = Math.round((mat + conf) / 2);
-      const radialDistance = threatRadius(indice, maxR);
-      const p = posFromPolar(radialDistance, angle);
-      const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      const category = item.categorie || 'autres';
+      const baseX = scaleX(fiabilite);
+      const baseY = scaleY(expo);
+      const radius = sizeForDependance(dep);
+      const pos = avoidOverlap(baseX, baseY, radius, placedPoints);
+      placedPoints.push({ x: pos.x, y: pos.y, r: radius });
+
+      const g = document.createElementNS(SVG_NS, 'g');
       g.setAttribute('class', 'radar-point');
       g.dataset.zone = zone.key;
+
+      const c = document.createElementNS(SVG_NS, 'circle');
+      c.setAttribute('cx', pos.x);
+      c.setAttribute('cy', pos.y);
+      c.setAttribute('r', radius);
+      c.setAttribute('fill', ssiColor(colorLvl));
+      c.setAttribute('stroke', categoryColours[category] || '#38bdf8');
+      c.setAttribute('stroke-width', '2');
+      c.setAttribute('opacity', '0.95');
+      c.setAttribute('filter', 'url(#softShadow)');
+      g.appendChild(c);
+
+      const showTooltip = (evt) => {
+        const box = svg.getBoundingClientRect();
+        tip.style.left = `${evt.clientX - box.left + 14}px`;
+        tip.style.top = `${evt.clientY - box.top - 18}px`;
+        tip.innerHTML = `<strong>${item.nom || 'PP'}</strong><br>` +
+          `Catégorie : ${categoryLabels[category] || 'Autre'}<br>` +
+          `Exposition : ${expo.toFixed(1)} – Fiabilité : ${fiabilite.toFixed(1)}<br>` +
+          `Indice de menace : ${indice.toFixed(2)} (${zone.label})`;
+        tip.style.opacity = 1;
+        tip.setAttribute('aria-hidden', 'false');
+      };
+      const moveTooltip = (evt) => {
+        const box = svg.getBoundingClientRect();
+        tip.style.left = `${evt.clientX - box.left + 14}px`;
+        tip.style.top = `${evt.clientY - box.top - 18}px`;
+      };
+      const hideTooltip = () => {
+        tip.style.opacity = 0;
+        tip.setAttribute('aria-hidden', 'true');
+      };
+
+      g.addEventListener('mouseenter', showTooltip);
+      g.addEventListener('mousemove', moveTooltip);
+      g.addEventListener('mouseleave', hideTooltip);
+
+      pointsLayer.appendChild(g);
+
       item.exposition = expo;
       item.fiabilite = fiabilite;
       item.indiceMenace = indice;
-      item.angle = angle;
-      item.rayon = radialDistance;
       item.zoneMenace = zone.key;
+      item.chartX = pos.x;
+      item.chartY = pos.y;
 
-      const c = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-      c.setAttribute('cx', p.x);
-      c.setAttribute('cy', p.y);
-      c.setAttribute('r', sizeForDependance(dep));
-      c.setAttribute('fill', ssiColor(colorLvl));
-      c.setAttribute('opacity', '0.95');
-      c.setAttribute('stroke', borderColor);
-      c.setAttribute('stroke-opacity', '0.25');
-      c.setAttribute('stroke-width', '1.4');
-      c.setAttribute('filter', 'url(#softShadow)');
-
-      const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-      t.setAttribute('x', p.x + 14);
-      t.setAttribute('y', p.y - 4);
-      t.setAttribute('class', 'radar-label radar-small');
-      t.textContent = item.nom || 'PP';
-
-      g.appendChild(c);
-      g.appendChild(t);
-      pointsLayer.appendChild(g);
-
-      g.addEventListener('mousemove', (evt) => {
-        const box = svg.getBoundingClientRect();
-        tip.style.left = (evt.clientX - box.left + 16) + 'px';
-        tip.style.top = (evt.clientY - box.top - 16) + 'px';
-        tip.style.opacity = 1;
-        tip.innerHTML = `<strong>${item.nom || 'PP'}</strong><br>` +
-          `Zone : ${zone.label}<br>` +
-          `Exposition : ${expo.toFixed(0)} – Fiabilité : ${fiabilite.toFixed(0)}<br>` +
-          `Indice de menace : ${indice.toFixed(2)}<br>` +
-          `Angle : ${angle}°`;
+      computedPoints.push({
+        item,
+        x: pos.x,
+        y: pos.y,
+        radius,
+        color: categoryColours[category] || '#38bdf8',
+        categoryLabel: categoryLabels[category] || 'Autre'
       });
-      g.addEventListener('mouseleave', () => { tip.style.opacity = 0; });
     });
+
+    const labelSpacing = 34;
+    const minY = plot.y + 18;
+    const maxY = plot.y + plot.height - 18;
+
+    const computeLabelPositions = (points) => {
+      if (!points.length) return [];
+      const positions = points.map(pt => clamp(pt.y, minY, maxY));
+      for (let i = 1; i < positions.length; i++) {
+        if (positions[i] < positions[i - 1] + labelSpacing) {
+          positions[i] = positions[i - 1] + labelSpacing;
+        }
+      }
+      const lastIndex = positions.length - 1;
+      if (positions[lastIndex] > maxY) {
+        positions[lastIndex] = maxY;
+        for (let i = lastIndex - 1; i >= 0; i--) {
+          const maxPos = positions[i + 1] - labelSpacing;
+          if (positions[i] > maxPos) {
+            positions[i] = maxPos;
+          }
+        }
+      }
+      if (positions[0] < minY) {
+        const shift = minY - positions[0];
+        for (let i = 0; i < positions.length; i++) {
+          positions[i] += shift;
+        }
+      }
+      for (let i = 1; i < positions.length; i++) {
+        if (positions[i] < positions[i - 1] + labelSpacing) {
+          positions[i] = Math.min(maxY, positions[i - 1] + labelSpacing);
+        }
+      }
+      return positions;
+    };
+
+    const placeLabels = (points, side) => {
+      const positions = computeLabelPositions(points);
+      const anchor = side === 'left' ? 'end' : 'start';
+      const labelX = side === 'left' ? plot.x - 200 : plot.x + plot.width + 200;
+      const elbowX = side === 'left' ? plot.x - 60 : plot.x + plot.width + 60;
+      const offsetX = side === 'left' ? -12 : 12;
+
+      points.forEach((point, idx) => {
+        const labelY = positions[idx];
+
+        const connector = document.createElementNS(SVG_NS, 'path');
+        connector.setAttribute('d', `M${labelX + offsetX},${labelY} L${elbowX},${labelY} L${point.x},${point.y}`);
+        connector.setAttribute('marker-end', 'url(#radar-arrow)');
+        connector.setAttribute('stroke', point.color);
+        connectorsLayer.appendChild(connector);
+
+        const text = document.createElementNS(SVG_NS, 'text');
+        text.setAttribute('class', 'radar-external-label');
+        text.setAttribute('x', labelX);
+        text.setAttribute('y', labelY);
+        text.setAttribute('text-anchor', anchor);
+        text.setAttribute('dominant-baseline', 'middle');
+
+        const nameSpan = document.createElementNS(SVG_NS, 'tspan');
+        nameSpan.textContent = point.item.nom || 'PP';
+        text.appendChild(nameSpan);
+
+        if (point.categoryLabel) {
+          const catSpan = document.createElementNS(SVG_NS, 'tspan');
+          catSpan.setAttribute('class', 'radar-external-sub');
+          catSpan.setAttribute('x', labelX);
+          catSpan.setAttribute('dy', '16');
+          catSpan.textContent = point.categoryLabel;
+          text.appendChild(catSpan);
+        }
+
+        labelsLayer.appendChild(text);
+      });
+    };
+
+    const leftPoints = computedPoints.filter(p => p.x < centerX).sort((a, b) => a.y - b.y);
+    const rightPoints = computedPoints.filter(p => p.x >= centerX).sort((a, b) => a.y - b.y);
+    placeLabels(leftPoints, 'left');
+    placeLabels(rightPoints, 'right');
   }
 
   function renderStrategicGraph() {

--- a/atelier3.html
+++ b/atelier3.html
@@ -69,165 +69,77 @@
         </div>
         <!-- Chart placed below the sub‑tab navigation and above the table -->
           <div id="atelier3-chart-container-top" class="chart-wrapper stakeholder-wrapper">
-          <div id="atelier3-radar-wrapper" class="stakeholder-diagram" role="img" aria-label="Diagramme des parties prenantes de l'atelier 3">
-            <svg viewBox="0 0 1200 640">
-
-              <!-- MARKERS -->
+          <div id="atelier3-radar-wrapper" class="stakeholder-diagram" role="group" aria-labelledby="atelier3-radar-title">
+            <svg id="atelier3-radar" viewBox="0 0 960 640" data-plot-x="230" data-plot-y="120" data-plot-width="500" data-plot-height="380" aria-labelledby="atelier3-radar-title" role="img">
+              <title id="atelier3-radar-title">Cartographie des parties prenantes : exposition vs fiabilité cyber</title>
               <defs>
-                <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-                  <path d="M0,0 10,5 0,10Z" fill="#c0392b" />
-                </marker>
-                <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-                  <path d="M0,0 10,5 0,10Z" fill="#3498db" />
-                </marker>
-                <marker id="arr-yellow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-                  <path d="M0,0 10,5 0,10Z" fill="#f1c40f" />
-                </marker>
-                <marker id="arr-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-                  <path d="M0,0 10,5 0,10Z" fill="#00c1b5" />
-                </marker>
-                <marker id="arr-grey" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-                  <path d="M0,0 10,5 0,10Z" fill="#c0c6d0" />
+                <filter id="softShadow" x="-40%" y="-40%" width="180%" height="180%">
+                  <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="rgba(15,23,42,0.35)" flood-opacity="0.55" />
+                </filter>
+                <marker id="radar-arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 L12,6 L0,12 Z" fill="#7dd3fc"></path>
                 </marker>
               </defs>
 
-              <!-- EN-TÊTES -->
-              <g class="label">
-                <rect class="pill" x="92" y="56" rx="16" ry="16" width="120" height="30"></rect>
-                <text class="tag" x="152" y="76" text-anchor="middle">CLIENTS</text>
-
-                <rect class="pill" x="92" y="236" rx="16" ry="16" width="155" height="30"></rect>
-                <text class="tag" x="169" y="256" text-anchor="middle">PRESTATAIRES</text>
-
-                <rect class="pill-blue" x="955" y="56" rx="16" ry="16" width="150" height="30"></rect>
-                <text class="tag" x="1030" y="76" text-anchor="middle">PARTENAIRES</text>
+              <g class="radar-zones">
+                <rect class="radar-zone zone-danger" x="230" y="120" width="250" height="190" rx="16" ry="16"></rect>
+                <rect class="radar-zone zone-controle" x="480" y="120" width="250" height="190" rx="16" ry="16"></rect>
+                <rect class="radar-zone zone-veille" x="230" y="310" width="250" height="190" rx="16" ry="16"></rect>
+                <rect class="radar-zone zone-confiance" x="480" y="310" width="250" height="190" rx="16" ry="16"></rect>
               </g>
 
-              <!-- LIBELLÉS GAUCHE -->
-              <g class="label">
-                <text x="64" y="116">C1 • Établissements de santé</text>
-                <text x="64" y="154">C2 • Pharmacies</text>
-                <text x="64" y="188">C3 • Dépositaires &amp; Grossistes réparateurs</text>
-
-                <text x="64" y="286">F3 • Prestataire informatique</text>
-                <text x="64" y="324">F2 • Fournisseurs de matériel</text>
-                <text x="64" y="356">F1 • Fournisseurs industriels chimistes</text>
+              <g class="radar-grid">
+                <rect class="radar-frame" x="230" y="120" width="500" height="380" rx="26" ry="26"></rect>
+                <line class="radar-axis" x1="480" y1="120" x2="480" y2="500"></line>
+                <line class="radar-axis" x1="230" y1="310" x2="730" y2="310"></line>
+                <line class="radar-grid-line" x1="230" y1="215" x2="730" y2="215"></line>
+                <line class="radar-grid-line" x1="230" y1="405" x2="730" y2="405"></line>
+                <line class="radar-grid-line" x1="355" y1="120" x2="355" y2="500"></line>
+                <line class="radar-grid-line" x1="605" y1="120" x2="605" y2="500"></line>
+                <text class="radar-zone-title" x="355" y="188" text-anchor="middle">Zone de danger</text>
+                <text class="radar-zone-title" x="605" y="188" text-anchor="middle">Zone de contrôle</text>
+                <text class="radar-zone-title" x="355" y="378" text-anchor="middle">Zone de veille</text>
+                <text class="radar-zone-title" x="605" y="378" text-anchor="middle">Zone de confiance</text>
+                <g class="radar-scale-y">
+                  <text x="218" y="126" text-anchor="end">16</text>
+                  <text x="218" y="221" text-anchor="end">12</text>
+                  <text x="218" y="316" text-anchor="end">8</text>
+                  <text x="218" y="411" text-anchor="end">4</text>
+                  <text x="218" y="506" text-anchor="end">0</text>
+                </g>
+                <g class="radar-scale-x">
+                  <text x="230" y="530" text-anchor="middle">0</text>
+                  <text x="355" y="530" text-anchor="middle">4</text>
+                  <text x="480" y="530" text-anchor="middle">8</text>
+                  <text x="605" y="530" text-anchor="middle">12</text>
+                  <text x="730" y="530" text-anchor="middle">16</text>
+                </g>
+                <text class="radar-axis-caption" x="480" y="560" text-anchor="middle">Fiabilité cyber</text>
+                <text class="radar-axis-caption" x="176" y="310" transform="rotate(-90 176 310)" text-anchor="middle">Exposition</text>
               </g>
 
-              <!-- LIBELLÉS DROITE -->
-              <g class="label">
-                <text x="935" y="140">P1 – Universités</text>
-                <text x="935" y="176">P2 – Régulateurs</text>
-                <text x="935" y="210">P3 – Laboratoires</text>
-              </g>
+              <g id="radar-connectors" class="radar-connectors"></g>
+              <g id="radar-points"></g>
+              <g id="radar-labels" class="radar-labels"></g>
 
-              <!-- CIBLE -->
-              <g transform="translate(610,320)">
-                <g fill="none" stroke="#4c5563" stroke-width="1" stroke-dasharray="2 7" opacity=".7">
-                  <circle r="45" /><circle r="90" /><circle r="135" /><circle r="180" /><circle r="225" />
+              <g class="radar-legend" transform="translate(770,120)">
+                <rect class="radar-legend-box" width="150" height="140" rx="14" ry="14"></rect>
+                <text x="20" y="32" class="radar-legend-title">Catégories</text>
+                <g class="radar-legend-item" transform="translate(20,48)">
+                  <circle cx="0" cy="0" r="6" class="legend-dot" data-cat="partenaire"></circle>
+                  <text x="16" y="4">Partenaire</text>
                 </g>
-                <g stroke="#7e8897" stroke-width="2" opacity=".85">
-                  <line x1="-245" y1="0" x2="245" y2="0" />
-                  <line x1="0" y1="-245" x2="0" y2="245" />
+                <g class="radar-legend-item" transform="translate(20,74)">
+                  <circle cx="0" cy="0" r="6" class="legend-dot" data-cat="prestataire"></circle>
+                  <text x="16" y="4">Prestataire</text>
                 </g>
-                <circle r="262" fill="none" stroke="#39b54a" stroke-width="14" />
-                <circle r="216" fill="none" stroke="#f39c12" stroke-width="14" />
-                <circle r="156" fill="none" stroke="#e74c3c" stroke-width="14" />
-                <circle r="18" fill="#7fa3c6" opacity=".25" />
-                <circle r="8" fill="#7fa3c6" opacity=".55" />
-
-                <line x1="0" y1="0" x2="170" y2="152" stroke="#aeb8c6" stroke-width="10" marker-end="url(#arr-grey)" />
-                <polygon points="118,106 152,144 98,162" fill="#c8ced7" opacity=".9" />
-                <g transform="translate(212,194) rotate(40)">
-                  <ellipse rx="28" ry="18" fill="#1e88e5"></ellipse>
-                  <rect x="-8" y="-5" width="92" height="10" rx="5" fill="#5b6674"></rect>
-                </g>
-
-                <g fill="#a8b2c3" font-size="12" text-anchor="middle">
-                  <text x="190" y="5">1</text><text x="150" y="5">2</text>
-                  <text x="110" y="5">3</text><text x="70" y="5">4</text>
-                  <text x="30" y="5">5</text><text x="-10" y="5">5</text>
-                </g>
-
-                <circle cx="-145" cy="-168" r="12" fill="#c62828" stroke="#5e0b0b" stroke-width="2" />
-                <circle cx="-190" cy="-64" r="11" fill="#29b6f6" stroke="#0b3a52" stroke-width="2" />
-                <circle cx="-205" cy="-18" r="12" fill="#1e88e5" stroke="#0b2a57" stroke-width="2" />
-
-                <circle cx="-96" cy="10" r="15" fill="#ffd21f" stroke="#7a5b00" stroke-width="2" />
-                <circle cx="-142" cy="88" r="18" fill="#1e88e5" stroke="#0b2a57" stroke-width="2" />
-                <circle cx="-84" cy="138" r="11" fill="#1e88e5" stroke="#0b2a57" stroke-width="2" />
-
-                <circle cx="132" cy="-132" r="12" fill="#c62828" stroke="#5e0b0b" stroke-width="2" />
-                <circle cx="100" cy="-150" r="11" fill="#00c1b5" stroke="#0a5954" stroke-width="2" />
-                <circle cx="74" cy="-70" r="12" fill="#ffd21f" stroke="#7a5b00" stroke-width="2" />
-              </g>
-
-              <!-- FLECHES GAUCHE -->
-              <g fill="none" stroke-width="2">
-                <line x1="328" y1="114" x2="458" y2="108" stroke="#c0392b" marker-end="url(#arr-red)" />
-                <line x1="290" y1="152" x2="398" y2="222" stroke="#3498db" marker-end="url(#arr-blue)" />
-                <line x1="324" y1="186" x2="402" y2="206" stroke="#3498db" marker-end="url(#arr-blue)" />
-
-                <line x1="322" y1="284" x2="470" y2="330" stroke="#f1c40f" marker-end="url(#arr-yellow)" />
-                <line x1="304" y1="322" x2="468" y2="374" stroke="#3498db" marker-end="url(#arr-blue)" />
-                <line x1="324" y1="354" x2="504" y2="414" stroke="#3498db" marker-end="url(#arr-blue)" />
-              </g>
-
-              <!-- FLECHES DROITE -->
-              <g fill="none" stroke-width="2">
-                <line x1="905" y1="138" x2="760" y2="120" stroke="#c0392b" marker-end="url(#arr-red)" />
-                <line x1="905" y1="174" x2="740" y2="116" stroke="#00c1b5" marker-end="url(#arr-cyan)" />
-                <line x1="905" y1="208" x2="760" y2="200" stroke="#f1c40f" marker-end="url(#arr-yellow)" />
-              </g>
-
-              <text x="812" y="324" fill="#a0acbd" font-size="12">Niveaux de menace</text>
-
-              <!-- LÉGENDE -->
-              <g transform="translate(890,352)">
-                <rect class="legendbox" width="280" height="210" rx="12" />
-                <g transform="translate(18,22)" fill="#e8ecf1">
-                  <text class="tag">EXPOSITION</text>
-                  <text class="small" y="18">= Dépendance × Pénétration</text>
-                  <g transform="translate(0,42)" fill="none" stroke="#e8ecf1" stroke-width="2">
-                    <circle cx="10" cy="8" r="5" /><circle cx="42" cy="8" r="8" /><circle cx="84" cy="8" r="11" /><circle cx="136" cy="8" r="14" />
-                  </g>
-                  <g transform="translate(0,42)" fill="#cfd6e3" class="small">
-                    <text x="0" y="32">&lt;3</text><text x="30" y="32">3-6</text><text x="72" y="32">7-9</text><text x="124" y="32">&gt;9</text>
-                  </g>
-
-                  <g transform="translate(0,104)" fill="#e8ecf1">
-                    <text class="tag">FIABILITÉ CYBER</text>
-                    <text class="small" y="18">= Maturité cyber × Confiance</text>
-                    <g transform="translate(0,34)">
-                      <circle cx="10" cy="6" r="6" fill="#c62828"></circle>
-                      <circle cx="42" cy="6" r="6" fill="#ffd21f"></circle>
-                      <circle cx="74" cy="6" r="6" fill="#1e88e5"></circle>
-                      <circle cx="106" cy="6" r="6" fill="#00c1b5"></circle>
-                      <text x="0" y="26" class="small" fill="#cfd6e3">&lt;4</text>
-                      <text x="32" y="26" class="small" fill="#cfd6e3">4-5</text>
-                      <text x="64" y="26" class="small" fill="#cfd6e3">6-7</text>
-                      <text x="96" y="26" class="small" fill="#cfd6e3">&gt;7</text>
-                    </g>
-                  </g>
-                </g>
-              </g>
-
-              <!-- BADGES ZONES -->
-              <g class="zoneBadge" transform="translate(470,598)" font-size="14" fill="#e8ecf1">
-                <g>
-                  <rect x="-12" y="-12" width="20" height="20" rx="4" fill="#39b54a" />
-                  <text x="16" y="0">Zone de veille</text>
-                </g>
-                <g transform="translate(168,0)">
-                  <rect x="-12" y="-12" width="20" height="20" rx="4" fill="#f39c12" />
-                  <text x="16" y="0">Zone de contrôle</text>
-                </g>
-                <g transform="translate(362,0)">
-                  <rect x="-12" y="-12" width="20" height="20" rx="4" fill="#e74c3c" />
-                  <text x="16" y="0">Zone de danger</text>
+                <g class="radar-legend-item" transform="translate(20,100)">
+                  <circle cx="0" cy="0" r="6" class="legend-dot" data-cat="beneficiaire"></circle>
+                  <text x="16" y="4">Bénéficiaire</text>
                 </g>
               </g>
             </svg>
+            <div id="atelier3-radar-tooltip" class="radar-tooltip" role="tooltip" aria-hidden="true"></div>
           </div>
         </div>
         <div class="atelier-grid">
@@ -250,7 +162,7 @@
                       <th>Exposition</th>
                       <th>Fiabilité cyber</th>
                       <th>Indice de menace</th>
-                      <th>Zone & angle</th>
+                      <th>Zone & valeurs</th>
                       <th>Actions</th>
                     </tr>
                   </thead>

--- a/styles.css
+++ b/styles.css
@@ -691,6 +691,7 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
 }
 
 #atelier3-radar-wrapper.stakeholder-diagram {
+  position: relative;
   background: #0b0f16;
   border-radius: 18px;
   border: 1px solid #1c2633;
@@ -698,6 +699,7 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
   padding: 1.5rem;
   display: grid;
   place-items: center;
+  overflow: visible;
 }
 
 #atelier3-radar-wrapper.stakeholder-diagram svg {
@@ -1261,6 +1263,107 @@ canvas {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+#atelier3-radar .radar-frame {
+  fill: rgba(15, 23, 42, 0.4);
+  stroke: rgba(148, 163, 184, 0.25);
+  stroke-width: 2;
+}
+
+#atelier3-radar .radar-axis {
+  stroke: rgba(148, 163, 184, 0.55);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+#atelier3-radar .radar-grid-line {
+  stroke: rgba(148, 163, 184, 0.28);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 6;
+}
+
+#atelier3-radar .radar-zone-title {
+  font-size: 14px;
+  fill: #e2e8f0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+#atelier3-radar .radar-scale-y text,
+#atelier3-radar .radar-scale-x text {
+  fill: #cbd5f5;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+#atelier3-radar .radar-axis-caption {
+  fill: #cbd5f5;
+  font-size: 13px;
+}
+
+#atelier3-radar .radar-legend {
+  pointer-events: none;
+  color: #e2e8f0;
+}
+
+#atelier3-radar .radar-legend-box {
+  fill: rgba(15, 23, 42, 0.72);
+  stroke: rgba(148, 163, 184, 0.25);
+  stroke-width: 1.5;
+}
+
+#atelier3-radar .radar-legend-title {
+  fill: #e2e8f0;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+#atelier3-radar .radar-legend-item text {
+  fill: #e2e8f0;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+#atelier3-radar .legend-dot[data-cat="partenaire"] {
+  fill: #0ea5e9;
+}
+
+#atelier3-radar .legend-dot[data-cat="prestataire"] {
+  fill: #f97316;
+}
+
+#atelier3-radar .legend-dot[data-cat="beneficiaire"] {
+  fill: #22c55e;
+}
+
+#atelier3-radar .radar-connectors path {
+  stroke: rgba(125, 211, 252, 0.8);
+  stroke-width: 1.8;
+  fill: none;
+}
+
+#atelier3-radar .radar-connectors,
+#atelier3-radar .radar-labels,
+#atelier3-radar .radar-external-label,
+#atelier3-radar .radar-external-sub {
+  pointer-events: none;
+}
+
+#atelier3-radar .radar-external-label {
+  fill: #f8fafc;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+#atelier3-radar .radar-external-sub {
+  fill: #cbd5f5;
+  font-size: 11px;
+  font-weight: 500;
 }
 
 .stakeholder-legend {


### PR DESCRIPTION
## Summary
- replace the static stakeholder illustration with a dynamic exposure vs fiabilité cyber diagram fed by the cartography table
- reposition stakeholder labels outside the grid with connectors while preventing overlapping points and showing tooltips
- refresh the associated styles to support the new quadrant layout, axes, and legend

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d68a9729e8832f8e46eba4d836e5eb