### PR TITLE
Fix Atelier 4 risk matrix to include scenario risks

### DIFF
--- a/app.js
+++ b/app.js
@@ -5961,12 +5961,34 @@
     }
 
     const analysis = analyses[currentIndex];
-    const risques = (analysis && analysis.data && Array.isArray(analysis.data.risques)) ? analysis.data.risques : [];
-    const data = risques.map(risk => {
+    const risquesList = [];
+    if (analysis && analysis.data) {
+      if (Array.isArray(analysis.data.risques)) {
+        risquesList.push(...analysis.data.risques);
+      }
+      if (Array.isArray(analysis.data.so)) {
+        analysis.data.so.forEach(scenario => {
+          if (!scenario || !Array.isArray(scenario.risks)) return;
+          scenario.risks.forEach(risk => {
+            if (!risk) return;
+            risquesList.push({
+              // Preserve name so the identifier can be derived for the chart label
+              name: risk.name,
+              gravite: risk.gravite,
+              vraisemblance: risk.vraisemblance,
+              description: risk.description
+            });
+          });
+        });
+      }
+    }
+
+    const data = risquesList.map(risk => {
       const gravite = parseLevel(risk.gravite, null);
       const vraisemblance = parseLevel(risk.vraisemblance, null);
       if (gravite === null || vraisemblance === null) return null;
-      const label = risk.libelle || risk.titre || formatRiskIdentifier(risk.indice || risk.id || '') || 'Risque';
+      const idPart = formatRiskIdentifier(risk.indice || risk.id || risk.name || '');
+      const label = risk.libelle || risk.titre || idPart || risk.name || 'Risque';
       return {
         name: label,
         value: [gravite, vraisemblance],


### PR DESCRIPTION
## Summary
- aggregate risks defined in Atelier 4 scenarios with the global risk list when building the risk matrix
- derive chart labels from the scenario risk name so the identifier before the dash is displayed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de83a2e580832fa8f33ed3d0b706cd