### PR TITLE
Improve risk matrix labels and inputs in atelier 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -6133,16 +6133,19 @@
           const gravite = parseLevel(risk.gravite, null);
           const vraisemblance = parseLevel(risk.vraisemblance, null);
           if (gravite === null || vraisemblance === null) return;
-          const idPart = formatRiskIdentifier(risk.indice || risk.id || risk.libelle || risk.titre || risk.name || '');
-          const label = risk.libelle || risk.titre || idPart || risk.name || 'Risque';
+          const rawIdentifier = risk.indice || risk.id || risk.libelle || risk.titre || risk.name || '';
+          const identifier = formatRiskIdentifier(rawIdentifier) || `R${idx + 1}`;
+          const fullName = risk.libelle || risk.titre || risk.name || rawIdentifier || `Risque ${idx + 1}`;
           const description = risk.description || risk.details || risk.detail || '';
           risquesList.push({
-            name: label,
+            name: identifier,
+            identifier,
+            fullName,
             value: [gravite, vraisemblance],
             rawValue: [gravite, vraisemblance],
             description,
-            meta: { type: 'global', riskId: risk.id || idPart || `global-${idx}` },
-            metaKey: `global::${risk.id || idPart || idx}`
+            meta: { type: 'global', riskId: risk.id || rawIdentifier || identifier || `global-${idx}` },
+            metaKey: `global::${risk.id || rawIdentifier || identifier || idx}`
           });
         });
       }
@@ -6155,15 +6158,18 @@
             const gravite = parseLevel(risk.gravite, null);
             const vraisemblance = parseLevel(risk.vraisemblance, null);
             if (gravite === null || vraisemblance === null) return;
-            const idPart = formatRiskIdentifier(risk.id || risk.name || '');
-            const label = risk.name || idPart || 'Risque';
+            const rawIdentifier = risk.id || risk.identifier || risk.code || risk.name || '';
+            const identifier = formatRiskIdentifier(rawIdentifier) || `S${sIdx + 1}-${rIdx + 1}`;
+            const fullName = risk.name || rawIdentifier || `Risque ${rIdx + 1}`;
             const description = risk.description || risk.details || risk.detail || '';
             risquesList.push({
-              name: label,
+              name: identifier,
+              identifier,
+              fullName,
               value: [gravite, vraisemblance],
               rawValue: [gravite, vraisemblance],
               description,
-              meta: { type: 'scenario', scenarioId, riskIndex: rIdx },
+              meta: { type: 'scenario', scenarioId, riskIndex: rIdx, riskId: rawIdentifier || identifier },
               metaKey: `scenario::${scenarioId}::${rIdx}`
             });
           });
@@ -6193,11 +6199,20 @@
         borderColor: accent,
         textStyle: { color: textPrimary },
         formatter: (params) => {
-          const desc = params.data && params.data.description ? `<br/><em>${params.data.description}</em>` : '';
-          const raw = params.data && params.data.rawValue ? params.data.rawValue : params.value;
+          const data = params.data || {};
+          const identifier = data.identifier || params.name || 'Risque';
+          const fullName = data.fullName && data.fullName !== identifier ? data.fullName : '';
+          const desc = data.description ? `<br/><em>${data.description}</em>` : '';
+          const raw = data.rawValue ? data.rawValue : params.value;
           const gravite = raw && raw[0] !== undefined ? raw[0] : params.value[0];
           const vraisemblance = raw && raw[1] !== undefined ? raw[1] : params.value[1];
-          return `<strong>${params.name}</strong>${desc}<br/>Gravité : ${gravite}<br/>Vraisemblance : ${vraisemblance}`;
+          let html = `<strong>${identifier}</strong>`;
+          if (fullName) {
+            html += `<br/>Nom : ${fullName}`;
+          }
+          html += desc;
+          html += `<br/>Gravité : ${gravite}<br/>Vraisemblance : ${vraisemblance}`;
+          return html;
         }
       },
       xAxis: {
@@ -6233,7 +6248,7 @@
           itemStyle: { color: accent },
           label: {
             show: true,
-            formatter: '{b}',
+            formatter: (params) => (params.data && params.data.identifier) ? params.data.identifier : params.name,
             color: textPrimary,
             fontSize: 12,
             position: 'top'

--- a/styles.css
+++ b/styles.css
@@ -1131,6 +1131,17 @@ canvas {
 #ops-table .assoc-item select {
   width: auto;
 }
+#ops-table .assoc-item input[type="number"] {
+  width: 3.2rem;
+  padding: 0.1rem 0.25rem;
+  font-size: 0.75rem;
+  text-align: center;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 3px;
+}
+#ops-table .assoc-item span {
+  white-space: nowrap;
+}
 
 /* Radar chart styles for Atelier 3 cartography */
 .radar-board {


### PR DESCRIPTION
## Summary
- align the Atelier 4 risk matrix with Atelier 5 by displaying identifiers as point labels
- expand tooltips to show the identifier, full name, and gravity/likelihood values on hover
- shrink the likelihood and gravity inputs in the operational scenarios table for a more compact layout

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df7cff7588832f9de215b64eeeaebf