### PR TITLE
Fix residual risk defaults when importing risks

### DIFF
--- a/app.js
+++ b/app.js
@@ -1766,7 +1766,7 @@
         const risk = riskMap.get(id);
         if (!risk) return;
         if (!analysis.data.actionsRisques.some(row => row.riskId === id)) {
-          analysis.data.actionsRisques.push({ riskId: id, riskName: risk.name, residualV: risk.vraisemblance, residualG: risk.gravite, actions: [] });
+          analysis.data.actionsRisques.push({ riskId: id, riskName: risk.name, residualV: 1, residualG: 1, actions: [] });
         }
       });
       saveAnalyses();


### PR DESCRIPTION
## Summary
- ensure new residual risk entries default to a neutral 1/1 level instead of copying the initial values

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df81740020832f94d21c16856eb6b8