### PR TITLE
Add carousel and severity distribution chart for atelier 5 risks

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@
   let risquesScoreChartInstance;
   let atelier4DragHandlers = null;
   let atelier5DragHandlers = null;
+  let riskChartCarouselIndex = 0;
 
   if (typeof window !== 'undefined') {
     window.addEventListener('resize', () => {
@@ -4277,6 +4278,62 @@
     addDataTableResizers('parties-actions-table');
   }
 
+  function updateRiskChartCarousel(index) {
+    const carousel = document.querySelector('.risk-chart-carousel');
+    if (!carousel) return;
+    const slides = carousel.querySelectorAll('.carousel-track .chart-canvas');
+    const dots = carousel.querySelectorAll('.carousel-dot');
+    if (!slides.length) return;
+    const maxIndex = slides.length - 1;
+    const targetIndex = Math.max(0, Math.min(index, maxIndex));
+    riskChartCarouselIndex = targetIndex;
+    slides.forEach((slide, idx) => {
+      const isActive = idx === targetIndex;
+      slide.classList.toggle('is-active', isActive);
+      slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      if (isActive) {
+        if (slide.id === 'risques-chart' && risquesChartInstance) {
+          risquesChartInstance.resize();
+        }
+        if (slide.id === 'risques-score-chart' && risquesScoreChartInstance) {
+          risquesScoreChartInstance.resize();
+        }
+      }
+    });
+    dots.forEach((dot, idx) => {
+      const isActive = idx === targetIndex;
+      dot.classList.toggle('active', isActive);
+      dot.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function setupRiskChartCarousel() {
+    const carousel = document.querySelector('.risk-chart-carousel');
+    if (!carousel) return;
+    if (carousel.dataset.initialized === 'true') {
+      updateRiskChartCarousel(riskChartCarouselIndex);
+      return;
+    }
+    const dots = carousel.querySelectorAll('.carousel-dot');
+    dots.forEach(dot => {
+      const targetIndex = Number(dot.getAttribute('data-target'));
+      const activate = () => {
+        if (!Number.isNaN(targetIndex)) {
+          updateRiskChartCarousel(targetIndex);
+        }
+      };
+      dot.addEventListener('click', activate);
+      dot.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          activate();
+        }
+      });
+    });
+    carousel.dataset.initialized = 'true';
+    updateRiskChartCarousel(riskChartCarouselIndex);
+  }
+
   // Render actions for risks: show each risk and allow adding actions and residual levels
   function renderRisquesChart() {
     const container = document.getElementById('risques-chart');
@@ -4290,6 +4347,8 @@
       return;
     }
     if (typeof echarts === 'undefined') return;
+
+    setupRiskChartCarousel();
 
     if (risquesChartInstance && risquesChartInstance.getDom() !== container) {
       risquesChartInstance.dispose();
@@ -4616,28 +4675,21 @@
       risquesScoreChartInstance = echarts.init(container);
     }
 
+    setupRiskChartCarousel();
+
     const accent = getCssVar('--accent', '#4da3ff');
     const danger = getCssVar('--danger', '#e74c3c');
     const textPrimary = getCssVar('--text-primary', '#e6e9ef');
     const textSecondary = getCssVar('--text-secondary', '#8aa0c4');
 
-    const formatScore = (val) => {
-      if (!Number.isFinite(val)) return '-';
-      let str = val.toFixed(5);
-      str = str.replace(/0+$/, '');
-      if (str.endsWith('.')) str = str.slice(0, -1);
-      return str;
-    };
-
     if (!points || !points.length) {
       risquesScoreChartInstance.setOption({
         backgroundColor: 'transparent',
         title: {
-          text: 'Indice de criticité (Initial vs Résiduel)',
+          text: 'Répartition des indices de criticité',
           left: 'center',
           textStyle: { color: textPrimary, fontSize: 18, fontWeight: 'bold' }
         },
-        grid: { left: 60, right: 30, top: 80, bottom: 80 },
         xAxis: {
           type: 'category',
           data: [],
@@ -4646,19 +4698,13 @@
           splitLine: { show: false }
         },
         yAxis: {
-          type: 'value',
+          type: 'category',
+          data: ['Initial', 'Résiduel'],
           axisLabel: { color: textSecondary },
           axisLine: { lineStyle: { color: textSecondary } },
-          splitLine: { lineStyle: { color: 'rgba(148,163,184,0.2)' } },
-          name: 'Indice',
-          nameTextStyle: { color: textSecondary },
-          min: 0
+          splitLine: { lineStyle: { color: 'rgba(148,163,184,0.2)' } }
         },
-        legend: {
-          data: ['Initial', 'Résiduel'],
-          top: 40,
-          textStyle: { color: textSecondary }
-        },
+        grid: { left: 50, right: 40, top: 80, bottom: 70 },
         series: [],
         graphic: [
           {
@@ -4676,69 +4722,130 @@
       return;
     }
 
-    const categories = points.map(point => point.name);
-    const initialValues = points.map(point => point.initial);
-    const residualValues = points.map(point => point.residual);
-    const shouldRotate = categories.some(name => (name || '').length > 12);
+    const severityRanges = [
+      { label: 'Insignifiant', range: [0, 1] },
+      { label: 'Faible', range: [1, 2] },
+      { label: 'Élevé', range: [2, 3] },
+      { label: 'Critique', range: [3, 4] },
+      { label: 'Maximal', range: [4, 5] }
+    ];
+    const types = ['Initial', 'Résiduel'];
+    const severityColors = ['#22c55e', '#84cc16', '#facc15', '#f97316', '#ef4444'];
+
+    const getSeverityIndex = (value) => {
+      for (let i = 0; i < severityRanges.length; i++) {
+        const [min, max] = severityRanges[i].range;
+        if (value >= min && value <= max) {
+          return i;
+        }
+      }
+      return severityRanges.length - 1;
+    };
+
+    const aggregationMap = new Map();
+    points.forEach(point => {
+      types.forEach(type => {
+        const value = type === 'Initial' ? Number(point.initial) : Number(point.residual);
+        if (!Number.isFinite(value)) return;
+        const normalizedValue = Math.max(0, Math.min(value, severityRanges[severityRanges.length - 1].range[1]));
+        const severityIndex = getSeverityIndex(normalizedValue);
+        const key = `${severityIndex}-${type}`;
+        let entry = aggregationMap.get(key);
+        if (!entry) {
+          entry = {
+            severityIndex,
+            type,
+            count: 0,
+            risks: []
+          };
+          aggregationMap.set(key, entry);
+        }
+        entry.count += 1;
+        if (point.name) {
+          entry.risks.push(point.name);
+        }
+      });
+    });
+
+    const aggregatedData = Array.from(aggregationMap.values());
+    const scatterData = aggregatedData.map(entry => {
+      const typeIndex = types.indexOf(entry.type);
+      return {
+        value: [entry.severityIndex, typeIndex, entry.count],
+        count: entry.count,
+        risks: entry.risks,
+        severityLabel: severityRanges[entry.severityIndex].label,
+        typeLabel: entry.type
+      };
+    });
 
     risquesScoreChartInstance.setOption({
       backgroundColor: 'transparent',
       title: {
-        text: 'Indice de criticité (Initial vs Résiduel)',
+        text: 'Répartition des indices de criticité',
         left: 'center',
         textStyle: { color: textPrimary, fontSize: 18, fontWeight: 'bold' }
       },
       tooltip: {
-        trigger: 'axis',
-        axisPointer: { type: 'shadow' },
+        position: 'top',
+        backgroundColor: '#0f172a',
+        borderColor: accent,
+        borderWidth: 1,
+        textStyle: { color: textPrimary },
         formatter: (params) => {
-          if (!Array.isArray(params)) return '';
-          const lines = [`<strong>${params[0].axisValue}</strong>`];
-          params.forEach(item => {
-            lines.push(`${item.marker || ''} ${item.seriesName}: ${formatScore(Number(item.data))}`);
-          });
-          return lines.join('<br/>');
+          if (!params || !params.data) return '';
+          const data = params.data;
+          const risksList = (data.risks && data.risks.length)
+            ? data.risks.join(', ')
+            : 'Aucun identifiant';
+          return `
+            <strong>${data.count} risque(s) ${data.severityLabel}</strong><br/>
+            ${data.typeLabel} : ${risksList}
+          `;
         }
       },
-      legend: {
-        data: ['Initial', 'Résiduel'],
-        top: 40,
-        textStyle: { color: textSecondary }
-      },
-      grid: { left: 60, right: 30, top: 80, bottom: shouldRotate ? 110 : 80 },
+      grid: { left: 60, right: 40, top: 80, bottom: 70 },
       xAxis: {
         type: 'category',
-        data: categories,
-        axisLabel: {
-          color: textSecondary,
-          rotate: shouldRotate ? 20 : 0
-        },
+        data: severityRanges.map(item => item.label),
+        boundaryGap: true,
+        axisLabel: { color: textSecondary },
+        axisLine: { lineStyle: { color: textSecondary } },
+        splitLine: { show: true, lineStyle: { color: 'rgba(148,163,184,0.15)' } }
+      },
+      yAxis: {
+        type: 'category',
+        data: types,
+        axisLabel: { color: textSecondary },
         axisLine: { lineStyle: { color: textSecondary } },
         splitLine: { show: false }
       },
-      yAxis: {
-        type: 'value',
-        axisLabel: { color: textSecondary },
-        axisLine: { lineStyle: { color: textSecondary } },
-        splitLine: { lineStyle: { color: 'rgba(148,163,184,0.2)' } },
-        name: 'Indice',
-        nameTextStyle: { color: textSecondary },
-        min: 0
-      },
       series: [
         {
-          name: 'Initial',
-          type: 'bar',
-          data: initialValues,
-          itemStyle: { color: danger },
-          emphasis: { focus: 'series' }
-        },
-        {
-          name: 'Résiduel',
-          type: 'bar',
-          data: residualValues,
-          itemStyle: { color: accent },
-          emphasis: { focus: 'series' }
+          name: 'Répartition',
+          type: 'scatter',
+          symbolSize: (val) => {
+            const base = Array.isArray(val) && val.length >= 3 ? Number(val[2]) : 0;
+            return Math.max(14, base * 14);
+          },
+          data: scatterData,
+          label: {
+            show: true,
+            position: 'top',
+            color: textPrimary,
+            formatter: (params) => {
+              const count = params && params.data ? params.data.count : 0;
+              return count > 0 ? `${count}` : '';
+            }
+          },
+          itemStyle: {
+            color: (params) => {
+              const severityIndex = Array.isArray(params.value) ? params.value[0] : 0;
+              return severityColors[severityIndex] || danger;
+            },
+            shadowBlur: 12,
+            shadowColor: 'rgba(15, 23, 42, 0.45)'
+          }
         }
       ],
       animationDuration: 300

--- a/atelier5.html
+++ b/atelier5.html
@@ -115,9 +115,15 @@
         <div id="atelier5-risques-tab" class="atelier5-subtab-content">
           <p>Pour chaque risque identifié dans l’atelier 4, indiquez les actions de traitement, le niveau de vraisemblance actuel et le niveau résiduel souhaité.</p>
           <div class="chart-wrapper">
-            <div class="risk-chart-grid">
-              <div id="risques-chart" class="chart-canvas chart-surface" role="img" aria-label="Matrice gravité vraisemblance"></div>
-              <div id="risques-score-chart" class="chart-canvas chart-surface" role="img" aria-label="Indice de criticité des risques (initial vs résiduel)"></div>
+            <div class="risk-chart-carousel" data-active-index="0">
+              <div class="carousel-track">
+                <div id="risques-chart" class="chart-canvas chart-surface is-active" role="img" aria-label="Matrice gravité vraisemblance" aria-hidden="false"></div>
+                <div id="risques-score-chart" class="chart-canvas chart-surface" role="img" aria-label="Indice de criticité des risques (initial vs résiduel)" aria-hidden="true"></div>
+              </div>
+              <div class="carousel-dots" role="tablist" aria-label="Diagrammes des risques">
+                <button type="button" class="carousel-dot active" data-target="0" aria-label="Afficher la matrice gravité vraisemblance" aria-controls="risques-chart" aria-pressed="true"></button>
+                <button type="button" class="carousel-dot" data-target="1" aria-label="Afficher l'indice de criticité" aria-controls="risques-score-chart" aria-pressed="false"></button>
+              </div>
             </div>
           </div>
           <div class="table-container">

--- a/styles.css
+++ b/styles.css
@@ -679,22 +679,60 @@ input[type="text"]:focus, input[type="number"]:focus, textarea:focus {
   position: relative;
 }
 
-.risk-chart-grid {
+.risk-chart-carousel {
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+  flex-direction: column;
   align-items: stretch;
-  justify-content: center;
+  gap: 0.75rem;
 }
 
-.risk-chart-grid .chart-canvas {
+.risk-chart-carousel .carousel-track {
+  position: relative;
+  min-height: 360px;
+}
+
+.risk-chart-carousel .chart-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   max-width: none;
   margin: 0;
-  flex: 1 1 320px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease;
 }
 
-.risk-chart-grid .chart-surface {
+.risk-chart-carousel .chart-canvas.is-active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.risk-chart-carousel .chart-surface {
   min-height: 360px;
+}
+
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.carousel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background-color: rgba(148, 163, 184, 0.35);
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.carousel-dot.active,
+.carousel-dot:focus-visible {
+  background-color: var(--accent);
+  transform: scale(1.15);
+  outline: none;
 }
 
 #atelier3-chart-container-top.stakeholder-wrapper {


### PR DESCRIPTION
## Summary
- wrap the atelier 5 risk matrix and score chart inside a carousel with navigation dots
- compute aggregated initial/residual indices and render a severity distribution scatter plot
- style the new carousel layout and ensure echarts instances resize when switching slides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd4761ef0832f9b99003c129dd2c6