### PR TITLE
Add detailed legend for atelier 3 stakeholder diagram

### DIFF
--- a/atelier3.html
+++ b/atelier3.html
@@ -73,6 +73,49 @@
             <div id="atelier3-stakeholder-chart" role="presentation" aria-hidden="true"></div>
           </div>
         </div>
+        <div class="stakeholder-legend" aria-label="Légende du diagramme des parties prenantes">
+          <div class="legend-block legend-block--zones">
+            <div class="legend-title">Catégories de parties prenantes</div>
+            <div class="legend-areas">
+              <span class="legend-chip"><span class="legend-square legend-square--beneficiaire" aria-hidden="true"></span>Bénéficiaire</span>
+              <span class="legend-chip"><span class="legend-square legend-square--partenaire" aria-hidden="true"></span>Partenaire</span>
+              <span class="legend-chip"><span class="legend-square legend-square--prestataire" aria-hidden="true"></span>Prestataire</span>
+              <span class="legend-chip"><span class="legend-square legend-square--interne" aria-hidden="true"></span>Interne / Autre</span>
+            </div>
+          </div>
+          <div class="legend-block">
+            <div class="legend-title">Exposition</div>
+            <div class="legend-scale legend-scale--bubbles" role="list">
+              <div class="legend-bubble" role="listitem">
+                <span class="bubble bubble-small" aria-hidden="true"></span>
+                <span class="bubble-label">Faible</span>
+              </div>
+              <div class="legend-bubble" role="listitem">
+                <span class="bubble bubble-medium" aria-hidden="true"></span>
+                <span class="bubble-label">Modérée</span>
+              </div>
+              <div class="legend-bubble" role="listitem">
+                <span class="bubble bubble-large" aria-hidden="true"></span>
+                <span class="bubble-label">Élevée</span>
+              </div>
+              <div class="legend-bubble" role="listitem">
+                <span class="bubble bubble-xlarge" aria-hidden="true"></span>
+                <span class="bubble-label">Critique</span>
+              </div>
+            </div>
+            <p class="legend-text">La taille du cercle reflète le niveau d'exposition (dépendance × pénétration).</p>
+          </div>
+          <div class="legend-block">
+            <div class="legend-title">Fiabilité cyber</div>
+            <div class="legend-scale" role="list">
+              <span class="legend-dot fiab-1" role="listitem">1</span>
+              <span class="legend-dot fiab-2" role="listitem">2</span>
+              <span class="legend-dot fiab-3" role="listitem">3</span>
+              <span class="legend-dot fiab-4" role="listitem">4</span>
+            </div>
+            <p class="legend-text">La couleur du cercle traduit la fiabilité cyber (maturité × confiance).</p>
+          </div>
+        </div>
         <div class="atelier-grid">
           <div class="left">
             <!-- Cartography sub‑tab -->

--- a/styles.css
+++ b/styles.css
@@ -1396,6 +1396,19 @@ canvas {
   border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
+.legend-chip .legend-square {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  margin-right: 8px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+}
+
+.legend-square--beneficiaire { background: #38bdf8; }
+.legend-square--partenaire { background: #6366f1; }
+.legend-square--prestataire { background: #f97316; }
+.legend-square--interne { background: #8b5cf6; }
+
 .chip-confiance { background: rgba(34, 197, 94, 0.22); }
 .chip-veille { background: rgba(250, 204, 21, 0.22); }
 .chip-controle { background: rgba(249, 115, 22, 0.22); }
@@ -1412,6 +1425,40 @@ canvas {
   gap: 10px;
 }
 
+.legend-scale--bubbles {
+  flex-wrap: wrap;
+  gap: 18px;
+}
+
+.legend-bubble {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 74px;
+  font-size: 0.75rem;
+  color: #334155;
+}
+
+.legend-bubble .bubble {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(96, 165, 250, 0.92), rgba(37, 99, 235, 0.9));
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.2);
+}
+
+.legend-bubble .bubble-small { width: 10px; height: 10px; }
+.legend-bubble .bubble-medium { width: 16px; height: 16px; }
+.legend-bubble .bubble-large { width: 22px; height: 22px; }
+.legend-bubble .bubble-xlarge { width: 28px; height: 28px; }
+
+.legend-bubble .bubble-label {
+  font-weight: 600;
+  color: #1e293b;
+}
+
 .legend-dot {
   width: 34px;
   height: 34px;
@@ -1424,6 +1471,11 @@ canvas {
   color: #ffffff;
   box-shadow: inset 0 0 0 2px rgba(15, 23, 42, 0.08);
 }
+
+.fiab-1 { background: #ef4444; }
+.fiab-2 { background: #f97316; }
+.fiab-3 { background: #facc15; color: #0f172a; }
+.fiab-4 { background: #22c55e; }
 
 .legend-scale--outline .legend-dot {
   background: #ffffff;


### PR DESCRIPTION
## Summary
- add a dedicated legend beneath the atelier 3 stakeholder chart with categories, exposition, and reliability details
- style the new legend items with colored squares and bubble/fiability indicators matching the chart semantics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b66da3af8832f9205ee6aca8299ca